### PR TITLE
feat: forms and validation with React Hook Form + Zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A production-ready React Native starter kit built on Expo SDK 54. Every feature 
 | Testing | Done | Jest + RNTL | -- | [docs](docs/getting-started.md#testing) |
 | NativeWind | Done | NativeWind v4 | -- | [docs](docs/nativewind.md) |
 | Auth | Coming soon | Amplify | Yes | -- |
-| Forms | Coming soon | -- | -- | -- |
+| Forms | Done | React Hook Form + Zod | -- | [docs](docs/features/forms.md) |
 | i18n | Coming soon | -- | -- | -- |
 | Analytics | Coming soon | Amplify | Yes | -- |
 | Crash Reporting | Coming soon | Sentry | Yes | -- |

--- a/docs/features/forms.md
+++ b/docs/features/forms.md
@@ -1,0 +1,124 @@
+# Forms & Validation
+
+## Overview
+
+Type-safe form components with integrated validation powered by **React Hook Form** and **Zod**. Includes ready-to-use input, select, and checkbox components styled with NativeWind, plus common validation schemas for typical fields like email and password.
+
+## Default Implementation
+
+- [React Hook Form](https://react-hook-form.com/) -- performant form state management with minimal re-renders
+- [Zod](https://zod.dev/) -- TypeScript-first schema validation
+- [@hookform/resolvers](https://github.com/react-hook-form/resolvers) -- connects Zod schemas to React Hook Form
+
+## Configuration
+
+In `src/config/starter.config.ts`:
+
+```ts
+features: {
+  forms: {
+    enabled: true, // set false to disable Zod validation
+  },
+}
+```
+
+When `enabled: false`, `useAppForm` returns a plain `useForm` instance without a Zod resolver. Components continue to work but without schema-based validation.
+
+## Usage
+
+### Basic form with validation
+
+```tsx
+import { z } from 'zod';
+import { FormProvider } from 'react-hook-form';
+import { useAppForm, FormInput, emailSchema, passwordSchema } from '@/features/forms';
+
+const loginSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+type LoginForm = z.infer<typeof loginSchema>;
+
+export function LoginScreen() {
+  const methods = useAppForm(loginSchema, {
+    defaultValues: { email: '', password: '' },
+  });
+
+  const onSubmit = methods.handleSubmit((data: LoginForm) => {
+    console.log(data);
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <FormInput name="email" label="Email" keyboardType="email-address" autoCapitalize="none" />
+      <FormInput name="password" label="Password" secureTextEntry />
+      <Pressable onPress={onSubmit}>
+        <Text>Sign In</Text>
+      </Pressable>
+    </FormProvider>
+  );
+}
+```
+
+### Using FormSelect
+
+```tsx
+import { FormSelect } from '@/features/forms';
+
+<FormSelect
+  name="role"
+  label="Role"
+  options={[
+    { label: 'Admin', value: 'admin' },
+    { label: 'User', value: 'user' },
+  ]}
+/>
+```
+
+### Using FormCheckbox
+
+```tsx
+import { FormCheckbox } from '@/features/forms';
+
+<FormCheckbox name="acceptTerms" label="I accept the terms and conditions" />
+```
+
+### Common schemas
+
+```ts
+import { emailSchema, passwordSchema, requiredString } from '@/features/forms';
+
+const schema = z.object({
+  email: emailSchema,            // valid email
+  password: passwordSchema,      // min 8 characters
+  name: requiredString,          // non-empty string
+});
+```
+
+## Components
+
+| Component | Props | Description |
+| --- | --- | --- |
+| `FormInput` | `name`, `label`, + `TextInputProps` | Controlled text input with error display |
+| `FormSelect` | `name`, `label`, `options` | Pressable dropdown with option list |
+| `FormCheckbox` | `name`, `label` | Toggle checkbox with check indicator |
+
+All components must be used inside a `<FormProvider>` from `react-hook-form`.
+
+## Removing the Feature
+
+**Option A** -- disable validation:
+
+```ts
+forms: { enabled: false },
+```
+
+`useAppForm` will skip the Zod resolver. Components still render but validation is not enforced.
+
+**Option B** -- delete entirely:
+
+1. Remove `src/features/forms/`.
+2. Remove the `forms` key from `starter.config.ts`.
+3. Remove any imports from `@/features/forms` in your code.
+4. Uninstall dependencies: `pnpm remove react-hook-form zod @hookform/resolvers`.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'jest-expo',
+  setupFiles: ['./test/jest-globals.ts'],
   setupFilesAfterEnv: ['./test/setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
@@ -36,6 +37,7 @@
     "nativewind": "^4.2.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hook-form": "^7.71.2",
     "react-native": "0.81.4",
     "react-native-css-interop": "^0.2.1",
     "react-native-gesture-handler": "~2.28.0",
@@ -46,6 +48,7 @@
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "tailwindcss": "3.4.17",
+    "zod": "^3.25.76",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.0.2(expo-font@14.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@19.1.0))
       '@react-native-async-storage/async-storage':
         specifier: ^3.0.1
         version: 3.0.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -74,6 +77,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@19.1.0)
       react-native:
         specifier: 0.81.4
         version: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
@@ -104,6 +110,9 @@ importers:
       tailwindcss:
         specifier: 3.4.17
         version: 3.4.17(ts-node@10.9.2(@types/node@24.7.1)(typescript@5.9.3))
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
@@ -867,6 +876,11 @@ packages:
     resolution: {integrity: sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw==}
     hasBin: true
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1438,6 +1452,9 @@ packages:
 
   '@sinonjs/fake-timers@15.1.1':
     resolution: {integrity: sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
@@ -4456,6 +4473,12 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -6567,6 +6590,11 @@ snapshots:
       find-up: 5.0.0
       js-yaml: 4.1.0
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.2(react@19.1.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -7319,6 +7347,8 @@ snapshots:
   '@sinonjs/fake-timers@15.1.1':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -11047,6 +11077,10 @@ snapshots:
   react-fast-compare@3.2.2: {}
 
   react-freeze@1.0.4(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  react-hook-form@7.71.2(react@19.1.0):
     dependencies:
       react: 19.1.0
 

--- a/src/features/forms/__tests__/form-input.test.tsx
+++ b/src/features/forms/__tests__/form-input.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { useForm, FormProvider } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { FormInput } from '../components/form-input';
+
+const schema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+function Wrapper({
+  defaultValues,
+  triggerErrors,
+  children,
+}: {
+  defaultValues?: Partial<FormValues>;
+  triggerErrors?: boolean;
+  children: React.ReactNode;
+}) {
+  const methods = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: defaultValues ?? { email: '' },
+  });
+
+  React.useEffect(() => {
+    if (triggerErrors) {
+      void methods.trigger();
+    }
+  }, [triggerErrors, methods]);
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe('FormInput', () => {
+  it('renders with the label text', () => {
+    render(
+      <Wrapper>
+        <FormInput name="email" label="Email Address" />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText('Email Address')).toBeTruthy();
+  });
+
+  it('shows error message when form has errors', async () => {
+    render(
+      <Wrapper defaultValues={{ email: 'not-an-email' }} triggerErrors>
+        <FormInput name="email" label="Email" />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByText('Invalid email address')).toBeTruthy();
+  });
+});

--- a/src/features/forms/components/form-checkbox.tsx
+++ b/src/features/forms/components/form-checkbox.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { useFormContext, Controller } from 'react-hook-form';
+
+export interface FormCheckboxProps {
+  name: string;
+  label: string;
+}
+
+export function FormCheckbox({ name, label }: FormCheckboxProps) {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <View className="mb-4">
+          <Pressable
+            className="flex-row items-center"
+            onPress={() => onChange(!value)}
+          >
+            <View
+              className={`h-5 w-5 rounded border mr-2 items-center justify-center ${
+                value
+                  ? 'bg-blue-500 border-blue-500'
+                  : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600'
+              }`}
+            >
+              {value && (
+                <Text className="text-white text-xs font-bold">✓</Text>
+              )}
+            </View>
+            <Text className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              {label}
+            </Text>
+          </Pressable>
+          {error?.message && (
+            <Text className="text-sm text-red-500 mt-1">{error.message}</Text>
+          )}
+        </View>
+      )}
+    />
+  );
+}

--- a/src/features/forms/components/form-input.tsx
+++ b/src/features/forms/components/form-input.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, Text, TextInput, type TextInputProps } from 'react-native';
+import { useFormContext, Controller } from 'react-hook-form';
+
+export interface FormInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
+  name: string;
+  label: string;
+}
+
+export function FormInput({ name, label, ...rest }: FormInputProps) {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+        <View className="mb-4">
+          <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {label}
+          </Text>
+          <TextInput
+            className={`border rounded-lg px-4 py-3 text-base text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800 ${
+              error
+                ? 'border-red-500'
+                : 'border-gray-300 dark:border-gray-600'
+            }`}
+            value={value}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            {...rest}
+          />
+          {error?.message && (
+            <Text className="text-sm text-red-500 mt-1">{error.message}</Text>
+          )}
+        </View>
+      )}
+    />
+  );
+}

--- a/src/features/forms/components/form-select.tsx
+++ b/src/features/forms/components/form-select.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { useFormContext, Controller } from 'react-hook-form';
+
+export interface FormSelectOption {
+  label: string;
+  value: string;
+}
+
+export interface FormSelectProps {
+  name: string;
+  label: string;
+  options: FormSelectOption[];
+}
+
+export function FormSelect({ name, label, options }: FormSelectProps) {
+  const { control } = useFormContext();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <View className="mb-4">
+          <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {label}
+          </Text>
+          <Pressable
+            className={`border rounded-lg px-4 py-3 bg-white dark:bg-gray-800 ${
+              error
+                ? 'border-red-500'
+                : 'border-gray-300 dark:border-gray-600'
+            }`}
+            onPress={() => setIsOpen((prev) => !prev)}
+          >
+            <Text className="text-base text-gray-900 dark:text-gray-100">
+              {options.find((o) => o.value === value)?.label || 'Select...'}
+            </Text>
+          </Pressable>
+          {isOpen && (
+            <View className="border border-gray-300 dark:border-gray-600 rounded-lg mt-1 bg-white dark:bg-gray-800">
+              {options.map((option) => (
+                <Pressable
+                  key={option.value}
+                  className={`px-4 py-3 ${
+                    value === option.value
+                      ? 'bg-blue-50 dark:bg-blue-900'
+                      : ''
+                  }`}
+                  onPress={() => {
+                    onChange(option.value);
+                    setIsOpen(false);
+                  }}
+                >
+                  <Text className="text-base text-gray-900 dark:text-gray-100">
+                    {option.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          )}
+          {error?.message && (
+            <Text className="text-sm text-red-500 mt-1">{error.message}</Text>
+          )}
+        </View>
+      )}
+    />
+  );
+}

--- a/src/features/forms/components/index.ts
+++ b/src/features/forms/components/index.ts
@@ -1,0 +1,3 @@
+export { FormInput, type FormInputProps } from './form-input';
+export { FormSelect, type FormSelectProps, type FormSelectOption } from './form-select';
+export { FormCheckbox, type FormCheckboxProps } from './form-checkbox';

--- a/src/features/forms/hooks/use-app-form.ts
+++ b/src/features/forms/hooks/use-app-form.ts
@@ -1,0 +1,20 @@
+import { useForm, type UseFormProps, type FieldValues } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { ZodSchema } from 'zod';
+import { starterConfig } from '@/config/starter.config';
+
+export function useAppForm<T extends FieldValues>(
+  schema: ZodSchema<T>,
+  options?: Omit<UseFormProps<T>, 'resolver'>,
+) {
+  if (!starterConfig.features.forms.enabled) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useForm<T>(options);
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useForm<T>({
+    resolver: zodResolver(schema),
+    ...options,
+  });
+}

--- a/src/features/forms/index.ts
+++ b/src/features/forms/index.ts
@@ -1,0 +1,5 @@
+export { useAppForm } from './hooks/use-app-form';
+export { FormInput, type FormInputProps } from './components/form-input';
+export { FormSelect, type FormSelectProps, type FormSelectOption } from './components/form-select';
+export { FormCheckbox, type FormCheckboxProps } from './components/form-checkbox';
+export { emailSchema, passwordSchema, requiredString } from './schemas/common';

--- a/src/features/forms/schemas/common.ts
+++ b/src/features/forms/schemas/common.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const emailSchema = z.string().email('Invalid email address');
+export const passwordSchema = z.string().min(8, 'Password must be at least 8 characters');
+export const requiredString = z.string().min(1, 'This field is required');

--- a/test/jest-globals.ts
+++ b/test/jest-globals.ts
@@ -1,0 +1,16 @@
+// Pre-define globals that Expo SDK 54 runtime sets up as lazy getters.
+// Jest 30 has stricter sandboxing that prevents require() calls inside
+// property getters on the global object. By eagerly defining these
+// globals before the Expo setup files run, we prevent the lazy getters
+// from being installed, avoiding the sandbox error.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const g = globalThis as any;
+
+if (!g.__ExpoImportMetaRegistry) {
+  g.__ExpoImportMetaRegistry = { url: null };
+}
+
+if (typeof g.structuredClone === 'undefined') {
+  g.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val));
+}


### PR DESCRIPTION
Closes #7

## Summary
- Form components (`FormInput`, `FormSelect`, `FormCheckbox`) with NativeWind styling and error display
- `useAppForm` hook wrapping `useForm` with Zod resolver (respects `forms.enabled` config toggle)
- Reusable validation schemas (`emailSchema`, `passwordSchema`, `requiredString`)
- Feature documentation at `docs/features/forms.md`
- README feature matrix updated

## Test plan
- [x] `pnpm test` passes (16 tests)
- [x] `pnpm lint` passes
- [ ] FormInput renders label and error messages correctly
- [ ] useAppForm validates against Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)