### PR TITLE
feat: add crash reporting with Sentry

### DIFF
--- a/docs/features/crash-reporting.md
+++ b/docs/features/crash-reporting.md
@@ -1,0 +1,99 @@
+# Crash Reporting
+
+The crash reporting feature provides a unified interface for capturing errors, exceptions, and diagnostic breadcrumbs in your React Native Expo app.
+
+## Configuration
+
+### Enable/Disable
+
+Toggle crash reporting in `src/config/starter.config.ts`:
+
+```ts
+crashReporting: { enabled: true, provider: 'sentry' },
+```
+
+Set `enabled: false` to disable crash reporting entirely. When disabled, all calls are no-ops with zero overhead.
+
+### Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `EXPO_PUBLIC_SENTRY_DSN` | Sentry DSN (required when using the Sentry provider) |
+
+### Install the Provider SDK
+
+When using Sentry, install the SDK:
+
+```bash
+pnpm add @sentry/react-native
+```
+
+Then create a development build:
+
+```bash
+npx expo run:ios
+npx expo run:android
+```
+
+## Usage
+
+Use the `useCrashReporting` hook inside any component:
+
+```tsx
+import { useCrashReporting } from '@/features/crash-reporting';
+
+function MyComponent() {
+  const crashReporting = useCrashReporting();
+
+  // Capture an exception
+  try {
+    riskyOperation();
+  } catch (error) {
+    crashReporting.captureException(error as Error);
+  }
+
+  // Capture a message
+  crashReporting.captureMessage('User completed onboarding', 'info');
+
+  // Set user context
+  crashReporting.setUser({ userId: '123', email: 'user@example.com' });
+
+  // Add a breadcrumb
+  crashReporting.addBreadcrumb('Navigated to settings', 'navigation');
+
+  // Clear user on logout
+  crashReporting.clearUser();
+}
+```
+
+## Adding a New Provider
+
+1. Create a new file at `src/features/crash-reporting/providers/<provider-name>.ts`.
+2. Implement the `CrashReportingService` interface from `@/services/crash-reporting.interface`.
+3. Export a factory function: `export function create<Name>CrashReporting(): CrashReportingService`.
+4. Register the provider in `src/features/crash-reporting/create-crash-reporting-service.ts`:
+
+```ts
+const providers: Record<string, () => Promise<CrashReportingService>> = {
+  sentry: async () => { /* ... */ },
+  '<provider-name>': async () => {
+    const { create<Name>CrashReporting } = await import('./providers/<provider-name>');
+    return create<Name>CrashReporting();
+  },
+};
+```
+
+5. Add the provider name to the `StarterConfig` type in `src/config/starter.config.ts` if it is not already listed.
+
+## Disabling the Feature
+
+Set `enabled: false` in `src/config/starter.config.ts`:
+
+```ts
+crashReporting: { enabled: false, provider: 'sentry' },
+```
+
+When disabled:
+- The `CrashReportingProvider` renders children directly without loading any SDK.
+- The `useCrashReporting` hook returns a no-op implementation.
+- No native modules are loaded, so no SDK installation is required.

--- a/src/features/crash-reporting/__tests__/crash-reporting.test.ts
+++ b/src/features/crash-reporting/__tests__/crash-reporting.test.ts
@@ -1,0 +1,116 @@
+import { noOpCrashReporting } from '../no-op-crash-reporting';
+
+describe('noOpCrashReporting', () => {
+  it('initialize does not throw', () => {
+    expect(() => noOpCrashReporting.initialize()).not.toThrow();
+  });
+
+  it('captureException does not throw', () => {
+    expect(() => noOpCrashReporting.captureException(new Error('test'))).not.toThrow();
+  });
+
+  it('captureMessage does not throw', () => {
+    expect(() => noOpCrashReporting.captureMessage('test')).not.toThrow();
+  });
+
+  it('setUser does not throw', () => {
+    expect(() => noOpCrashReporting.setUser({ userId: 'u1' })).not.toThrow();
+  });
+
+  it('clearUser does not throw', () => {
+    expect(() => noOpCrashReporting.clearUser()).not.toThrow();
+  });
+
+  it('addBreadcrumb does not throw', () => {
+    expect(() => noOpCrashReporting.addBreadcrumb('clicked', 'ui')).not.toThrow();
+  });
+});
+
+describe('createCrashReportingService', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns noOpCrashReporting when feature is disabled', async () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        features: {
+          crashReporting: { enabled: false, provider: 'sentry' },
+        },
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createCrashReportingService } = require('../create-crash-reporting-service') as {
+      createCrashReportingService: () => Promise<typeof noOpCrashReporting>;
+    };
+    const service = await createCrashReportingService();
+
+    expect(() => service.initialize()).not.toThrow();
+    expect(() => service.captureException(new Error('test'))).not.toThrow();
+    expect(() => service.captureMessage('test')).not.toThrow();
+  });
+
+  it('throws for unknown provider', async () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        features: {
+          crashReporting: {
+            enabled: true,
+            provider: 'unknown-provider',
+          },
+        },
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createCrashReportingService } = require('../create-crash-reporting-service') as {
+      createCrashReportingService: () => Promise<typeof noOpCrashReporting>;
+    };
+    await expect(createCrashReportingService()).rejects.toThrow(
+      'Unknown crash reporting provider: unknown-provider',
+    );
+  });
+
+  it('returns noOpCrashReporting on provider failure', async () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        features: {
+          crashReporting: { enabled: true, provider: 'sentry' },
+        },
+      },
+    }));
+
+    jest.mock('../providers/sentry', () => {
+      throw new Error('Module not found');
+    });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createCrashReportingService } = require('../create-crash-reporting-service') as {
+      createCrashReportingService: () => Promise<typeof noOpCrashReporting>;
+    };
+    const service = await createCrashReportingService();
+
+    expect(() => service.initialize()).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to load "sentry" provider'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe('useCrashReporting', () => {
+  it('returns noOpCrashReporting when no provider is set', () => {
+    // When context value is null (no provider), the hook returns noOpCrashReporting.
+    // We verify this by testing the fallback directly since useContext(CrashReportingContext)
+    // defaults to null when no provider wraps the component.
+    const service = noOpCrashReporting;
+
+    expect(() => service.initialize()).not.toThrow();
+    expect(() => service.captureException(new Error('test'))).not.toThrow();
+    expect(() => service.captureMessage('test')).not.toThrow();
+  });
+});

--- a/src/features/crash-reporting/crash-reporting-provider.tsx
+++ b/src/features/crash-reporting/crash-reporting-provider.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useEffect, useState } from 'react';
+import type { CrashReportingService } from '@/services/crash-reporting.interface';
+import { starterConfig } from '@/config/starter.config';
+import { createCrashReportingService } from './create-crash-reporting-service';
+
+export const CrashReportingContext = createContext<CrashReportingService | null>(null);
+
+function CrashReportingProviderInner({ children }: { children: React.ReactNode }) {
+  const [service, setService] = useState<CrashReportingService | null>(null);
+
+  useEffect(() => {
+    createCrashReportingService().then(setService);
+  }, []);
+
+  if (!service) return null;
+
+  return (
+    <CrashReportingContext.Provider value={service}>
+      {children}
+    </CrashReportingContext.Provider>
+  );
+}
+
+export function CrashReportingProvider({ children }: { children: React.ReactNode }) {
+  if (!starterConfig.features.crashReporting.enabled) {
+    return <>{children}</>;
+  }
+
+  return <CrashReportingProviderInner>{children}</CrashReportingProviderInner>;
+}

--- a/src/features/crash-reporting/create-crash-reporting-service.ts
+++ b/src/features/crash-reporting/create-crash-reporting-service.ts
@@ -1,0 +1,30 @@
+import type { CrashReportingService } from '@/services/crash-reporting.interface';
+import { starterConfig } from '@/config/starter.config';
+import { noOpCrashReporting } from './no-op-crash-reporting';
+
+const providers: Record<string, () => Promise<CrashReportingService>> = {
+  sentry: async () => {
+    const { createSentryCrashReporting } = await import('./providers/sentry');
+    return createSentryCrashReporting();
+  },
+};
+
+export async function createCrashReportingService(): Promise<CrashReportingService> {
+  if (!starterConfig.features.crashReporting.enabled) {
+    return noOpCrashReporting;
+  }
+
+  const { provider } = starterConfig.features.crashReporting;
+  const factory = providers[provider];
+  if (!factory) throw new Error(`Unknown crash reporting provider: ${provider}`);
+
+  try {
+    return await factory();
+  } catch {
+    console.warn(
+      `[crash-reporting] Failed to load "${provider}" provider (native module not available). Falling back to no-op crash reporting. ` +
+      `If you need crash reporting, install the provider SDK and create a dev build with: npx expo run:ios / npx expo run:android`,
+    );
+    return noOpCrashReporting;
+  }
+}

--- a/src/features/crash-reporting/hooks/use-crash-reporting.ts
+++ b/src/features/crash-reporting/hooks/use-crash-reporting.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { CrashReportingContext } from '../crash-reporting-provider';
+import { noOpCrashReporting } from '../no-op-crash-reporting';
+
+export function useCrashReporting() {
+  const service = useContext(CrashReportingContext);
+
+  if (!service) {
+    return noOpCrashReporting;
+  }
+
+  return service;
+}

--- a/src/features/crash-reporting/index.ts
+++ b/src/features/crash-reporting/index.ts
@@ -1,0 +1,3 @@
+export { CrashReportingProvider } from './crash-reporting-provider';
+export { useCrashReporting } from './hooks/use-crash-reporting';
+export { createCrashReportingService } from './create-crash-reporting-service';

--- a/src/features/crash-reporting/no-op-crash-reporting.ts
+++ b/src/features/crash-reporting/no-op-crash-reporting.ts
@@ -1,0 +1,10 @@
+import type { CrashReportingService } from '@/services/crash-reporting.interface';
+
+export const noOpCrashReporting: CrashReportingService = {
+  initialize: () => {},
+  captureException: () => {},
+  captureMessage: () => {},
+  setUser: () => {},
+  clearUser: () => {},
+  addBreadcrumb: () => {},
+};

--- a/src/features/crash-reporting/providers/sentry.ts
+++ b/src/features/crash-reporting/providers/sentry.ts
@@ -1,0 +1,34 @@
+import type { CrashReportingService } from '@/services/crash-reporting.interface';
+
+export function createSentryCrashReporting(): CrashReportingService {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Sentry = require('@sentry/react-native');
+
+  return {
+    initialize() {
+      Sentry.init({
+        dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+      });
+    },
+
+    captureException(error, context) {
+      Sentry.captureException(error, context ? { extra: context } : undefined);
+    },
+
+    captureMessage(message, level) {
+      Sentry.captureMessage(message, level);
+    },
+
+    setUser(user) {
+      Sentry.setUser(user);
+    },
+
+    clearUser() {
+      Sentry.setUser(null);
+    },
+
+    addBreadcrumb(message, category, data) {
+      Sentry.addBreadcrumb({ message, category, data });
+    },
+  };
+}

--- a/src/lib/providers/app-providers.tsx
+++ b/src/lib/providers/app-providers.tsx
@@ -5,6 +5,7 @@ import { StorageProvider } from '@/features/offline-storage';
 import { AuthProvider } from '@/features/auth';
 import { configureAmplify } from '@/lib/amplify/configure';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { CrashReportingProvider } from '@/features/crash-reporting';
 import { I18nProvider } from '@/features/i18n';
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
@@ -22,11 +23,13 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
       <QueryProvider>
         <StorageProvider>
           <AuthProvider>
-            {/* Analytics, CrashReporting providers added here by future tasks */}
-            <I18nProvider>
-              {/* Notifications provider added here by future tasks */}
-              {children}
-            </I18nProvider>
+            {/* Analytics provider added here by future tasks */}
+            <CrashReportingProvider>
+              <I18nProvider>
+                {/* Notifications provider added here by future tasks */}
+                {children}
+              </I18nProvider>
+            </CrashReportingProvider>
           </AuthProvider>
         </StorageProvider>
       </QueryProvider>


### PR DESCRIPTION
## Summary
- Add crash reporting feature with Sentry as default provider
- Implement factory pattern with dynamic imports and no-op fallback
- Add CrashReportingProvider, useCrashReporting hook
- Integrate into AppProviders composition (after Auth, before I18n)
- Add developer guide documentation

Closes #13

## Test plan
- [x] All 39 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] No-op fallback works when feature disabled
- [x] Provider renders children when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)