### PR TITLE
feat: add deep linking with expo-linking

### DIFF
--- a/docs/features/deep-linking.md
+++ b/docs/features/deep-linking.md
@@ -1,0 +1,114 @@
+# Deep Linking
+
+Deep linking allows users to open specific screens in your app via URLs. Expo Router handles most of the heavy lifting automatically — every route in your `app/` directory is already a valid deep link target.
+
+## How It Works
+
+Expo Router uses file-based routing, which means deep links map directly to your file structure:
+
+| URL | Route File |
+| --- | --- |
+| `myapp://home` | `app/home.tsx` |
+| `myapp://profile/123` | `app/profile/[id].tsx` |
+| `myapp://settings` | `app/settings.tsx` |
+
+No additional route configuration is needed. Expo Router and `expo-linking` handle the URL-to-route mapping automatically.
+
+## Configuration
+
+### URL Scheme
+
+The URL scheme is configured in `src/config/starter.config.ts`:
+
+```typescript
+export const starterConfig: StarterConfig = {
+  app: {
+    scheme: 'myapp', // Your custom URL scheme
+  },
+  features: {
+    deepLinking: { enabled: true },
+  },
+};
+```
+
+The scheme is also set in `app.json` / `app.config.ts` under the `scheme` field, which Expo uses at build time. Make sure both values match.
+
+## Utilities
+
+### `useDeepLink` Hook
+
+Listens for incoming deep links and provides the most recent URL:
+
+```typescript
+import { useDeepLink } from '@/features/deep-linking';
+
+export default function RootLayout() {
+  const { lastUrl } = useDeepLink();
+
+  useEffect(() => {
+    if (lastUrl) {
+      console.log('App opened with URL:', lastUrl);
+    }
+  }, [lastUrl]);
+
+  return <Stack />;
+}
+```
+
+The hook handles two scenarios:
+- **Cold start**: The app was opened via a deep link (uses `Linking.getInitialURL()`)
+- **Warm resume**: A deep link arrived while the app was already running (uses `Linking.addEventListener`)
+
+When `features.deepLinking.enabled` is `false`, the hook skips all listeners and returns `null`.
+
+### `buildDeepLink` Utility
+
+Constructs a deep link URL using the configured scheme:
+
+```typescript
+import { buildDeepLink } from '@/features/deep-linking';
+
+const url = buildDeepLink('/profile/123');
+// => 'myapp://profile/123'
+
+const url2 = buildDeepLink('settings');
+// => 'myapp://settings'
+```
+
+This is useful for generating share links or triggering navigation programmatically via `Linking.openURL()`.
+
+## Universal Links (HTTPS Deep Links)
+
+For production apps, you should also configure universal links (iOS) and app links (Android) so that HTTPS URLs open your app:
+
+1. **iOS**: Add an `apple-app-site-association` file to your web domain
+2. **Android**: Add `assetlinks.json` to your web domain's `.well-known` directory
+3. **Expo Config**: Add `intentFilters` (Android) and `associatedDomains` (iOS) to your `app.json`
+
+Refer to the [Expo deep linking guide](https://docs.expo.dev/guides/deep-linking/) for detailed setup instructions.
+
+## Disabling Deep Linking
+
+Set `features.deepLinking.enabled` to `false` in `starter.config.ts`. This disables the `useDeepLink` hook listener. Note that expo-router still handles basic URL routing — this flag only controls the custom hook and utilities provided by this feature.
+
+## Testing Deep Links
+
+Use the `uri-scheme` CLI to test deep links during development:
+
+```bash
+# iOS Simulator
+npx uri-scheme open myapp://profile/123 --ios
+
+# Android Emulator
+npx uri-scheme open myapp://profile/123 --android
+
+# Or use adb directly
+adb shell am start -a android.intent.action.VIEW -d "myapp://profile/123"
+```
+
+You can also test from a terminal with Expo Go running:
+
+```bash
+npx expo start --dev-client
+# Then open a deep link in another terminal
+```

--- a/src/features/deep-linking/__tests__/deep-linking.test.ts
+++ b/src/features/deep-linking/__tests__/deep-linking.test.ts
@@ -1,0 +1,112 @@
+import * as Linking from 'expo-linking';
+import { renderHook } from '@testing-library/react-native';
+import { useDeepLink } from '../hooks/use-deep-link';
+import { starterConfig } from '@/config/starter.config';
+
+jest.mock('expo-linking', () => ({
+  getInitialURL: jest.fn().mockResolvedValue(null),
+  addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+}));
+
+jest.mock('@/config/starter.config', () => ({
+  starterConfig: {
+    app: { scheme: 'myapp' },
+    features: { deepLinking: { enabled: true } },
+  },
+}));
+
+describe('buildDeepLink', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('constructs correct URL from config scheme', () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        app: { scheme: 'myapp' },
+        features: { deepLinking: { enabled: true } },
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildDeepLink } = require('../utils/build-deep-link') as {
+      buildDeepLink: (path: string) => string;
+    };
+
+    expect(buildDeepLink('profile/123')).toBe('myapp://profile/123');
+  });
+
+  it('handles path with leading slash', () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        app: { scheme: 'myapp' },
+        features: { deepLinking: { enabled: true } },
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildDeepLink } = require('../utils/build-deep-link') as {
+      buildDeepLink: (path: string) => string;
+    };
+
+    expect(buildDeepLink('/settings')).toBe('myapp://settings');
+  });
+
+  it('handles path without leading slash', () => {
+    jest.mock('@/config/starter.config', () => ({
+      starterConfig: {
+        app: { scheme: 'testapp' },
+        features: { deepLinking: { enabled: true } },
+      },
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildDeepLink } = require('../utils/build-deep-link') as {
+      buildDeepLink: (path: string) => string;
+    };
+
+    expect(buildDeepLink('home')).toBe('testapp://home');
+  });
+});
+
+describe('useDeepLink', () => {
+  const mockGetInitialURL = Linking.getInitialURL as jest.Mock;
+  const mockAddEventListener = Linking.addEventListener as jest.Mock;
+  const mockConfig = starterConfig as { app: { scheme: string }; features: { deepLinking: { enabled: boolean } } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetInitialURL.mockResolvedValue(null);
+    mockAddEventListener.mockReturnValue({ remove: jest.fn() });
+    mockConfig.features.deepLinking.enabled = true;
+  });
+
+  it('returns null initially when deep linking is disabled', () => {
+    mockConfig.features.deepLinking.enabled = false;
+
+    const { result } = renderHook(() => useDeepLink());
+    expect(result.current.lastUrl).toBeNull();
+    expect(mockGetInitialURL).not.toHaveBeenCalled();
+    expect(mockAddEventListener).not.toHaveBeenCalled();
+  });
+
+  it('returns null initially when deep linking is enabled but no URL', () => {
+    const { result } = renderHook(() => useDeepLink());
+    expect(result.current.lastUrl).toBeNull();
+  });
+
+  it('calls getInitialURL and addEventListener when enabled', () => {
+    renderHook(() => useDeepLink());
+    expect(mockGetInitialURL).toHaveBeenCalled();
+    expect(mockAddEventListener).toHaveBeenCalledWith('url', expect.any(Function));
+  });
+
+  it('cleans up subscription on unmount', () => {
+    const removeMock = jest.fn();
+    mockAddEventListener.mockReturnValue({ remove: removeMock });
+
+    const { unmount } = renderHook(() => useDeepLink());
+    unmount();
+    expect(removeMock).toHaveBeenCalled();
+  });
+});

--- a/src/features/deep-linking/hooks/use-deep-link.ts
+++ b/src/features/deep-linking/hooks/use-deep-link.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import * as Linking from 'expo-linking';
+import { starterConfig } from '@/config/starter.config';
+
+export function useDeepLink() {
+  const [lastUrl, setLastUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!starterConfig.features.deepLinking.enabled) return;
+
+    // Get initial URL (app opened via deep link)
+    Linking.getInitialURL().then((url) => {
+      if (url) setLastUrl(url);
+    });
+
+    // Listen for incoming URLs while app is open
+    const subscription = Linking.addEventListener('url', (event) => {
+      setLastUrl(event.url);
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  return { lastUrl };
+}

--- a/src/features/deep-linking/index.ts
+++ b/src/features/deep-linking/index.ts
@@ -1,0 +1,2 @@
+export { useDeepLink } from './hooks/use-deep-link';
+export { buildDeepLink } from './utils/build-deep-link';

--- a/src/features/deep-linking/utils/build-deep-link.ts
+++ b/src/features/deep-linking/utils/build-deep-link.ts
@@ -1,0 +1,8 @@
+import { starterConfig } from '@/config/starter.config';
+
+export function buildDeepLink(path: string): string {
+  const scheme = starterConfig.app.scheme;
+  // Remove leading slash if present
+  const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+  return `${scheme}://${cleanPath}`;
+}


### PR DESCRIPTION
## Summary
- Add deep linking feature with useDeepLink hook and buildDeepLink utility
- Leverages expo-router's automatic route mapping
- Config-driven enable/disable with URL scheme from starter.config
- Add developer guide documentation

Closes #19

## Test plan
- [x] All 65 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Hook respects config toggle
- [x] buildDeepLink constructs correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)