### PR TITLE
feat: add OTA updates with expo-updates

### DIFF
--- a/docs/features/ota-updates.md
+++ b/docs/features/ota-updates.md
@@ -1,0 +1,101 @@
+# OTA Updates
+
+Over-the-air (OTA) updates allow you to push JavaScript and asset changes to your app without going through the app store review process. This feature uses `expo-updates` under the hood.
+
+## How It Works
+
+When your app launches (or when you explicitly check), `expo-updates` contacts the update server to see if a new bundle is available. If one is found, it can be downloaded and applied — either immediately with a reload or on the next app launch.
+
+## Configuration
+
+Toggle OTA updates in `src/config/starter.config.ts`:
+
+```typescript
+export const starterConfig: StarterConfig = {
+  features: {
+    otaUpdates: { enabled: true },
+  },
+};
+```
+
+When `enabled` is `false`, the `useOtaUpdates` hook becomes a no-op — no network requests are made and no updates are checked or applied.
+
+## Using the `useOtaUpdates` Hook
+
+```typescript
+import { useOtaUpdates } from '@/features/ota-updates';
+
+function MyComponent() {
+  const { status, checkForUpdate, downloadAndApply } = useOtaUpdates();
+
+  // status.isChecking    — true while checking for an update
+  // status.isDownloading — true while downloading an update
+  // status.isAvailable   — true if an update was found
+  // status.error         — error message string, or null
+
+  return (
+    <View>
+      <Button title="Check for updates" onPress={checkForUpdate} />
+      {status.isAvailable && (
+        <Button title="Download & restart" onPress={downloadAndApply} />
+      )}
+      {status.error && <Text>Error: {status.error}</Text>}
+    </View>
+  );
+}
+```
+
+## Example: Check on App Foreground
+
+You can automatically check for updates each time the app returns to the foreground:
+
+```typescript
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useOtaUpdates } from '@/features/ota-updates';
+
+export function useAutoUpdateCheck() {
+  const { checkForUpdate } = useOtaUpdates();
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        checkForUpdate();
+      }
+    });
+
+    return () => subscription.remove();
+  }, [checkForUpdate]);
+}
+```
+
+## EAS Update Setup
+
+To publish OTA updates you need [EAS Update](https://docs.expo.dev/eas-update/introduction/) configured:
+
+1. Install the EAS CLI:
+   ```bash
+   pnpm add -g eas-cli
+   ```
+
+2. Configure your project:
+   ```bash
+   eas update:configure
+   ```
+
+3. Publish an update:
+   ```bash
+   eas update --branch production --message "Bug fixes"
+   ```
+
+Make sure `expo-updates` is installed as a dependency for standalone builds:
+
+```bash
+pnpm add expo-updates
+```
+
+The `expo-updates` package is part of the Expo ecosystem but must be installed separately. In Expo Go, update checking is not available — the hook uses `require('expo-updates')` at runtime to avoid import errors in that environment.
+
+## Disabling the Feature
+
+Set `features.otaUpdates.enabled` to `false` in `starter.config.ts`. The `useOtaUpdates` hook will return the default status (all `false`/`null`) and calling `checkForUpdate` or `downloadAndApply` will be no-ops. No `expo-updates` code will be executed.

--- a/src/features/ota-updates/__tests__/ota-updates.test.ts
+++ b/src/features/ota-updates/__tests__/ota-updates.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useOtaUpdates } from '../hooks/use-ota-updates';
+import { starterConfig } from '@/config/starter.config';
+
+jest.mock(
+  'expo-updates',
+  () => ({
+    checkForUpdateAsync: jest.fn(),
+    fetchUpdateAsync: jest.fn(),
+    reloadAsync: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock('@/config/starter.config', () => ({
+  starterConfig: {
+    features: { otaUpdates: { enabled: true } },
+  },
+}));
+
+describe('useOtaUpdates', () => {
+  const mockConfig = starterConfig as {
+    features: { otaUpdates: { enabled: boolean } };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig.features.otaUpdates.enabled = true;
+  });
+
+  it('returns initial status with all false/null', () => {
+    const { result } = renderHook(() => useOtaUpdates());
+
+    expect(result.current.status).toEqual({
+      isChecking: false,
+      isDownloading: false,
+      isAvailable: false,
+      error: null,
+    });
+  });
+
+  it('checkForUpdate does nothing when feature is disabled', async () => {
+    mockConfig.features.otaUpdates.enabled = false;
+
+    const { result } = renderHook(() => useOtaUpdates());
+    await act(async () => {
+      await result.current.checkForUpdate();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Updates = require('expo-updates');
+    expect(Updates.checkForUpdateAsync).not.toHaveBeenCalled();
+  });
+
+  it('checkForUpdate sets isChecking then resolves with availability', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Updates = require('expo-updates');
+    (Updates.checkForUpdateAsync as jest.Mock).mockResolvedValue({
+      isAvailable: true,
+    });
+
+    const { result } = renderHook(() => useOtaUpdates());
+
+    await act(async () => {
+      await result.current.checkForUpdate();
+    });
+
+    expect(Updates.checkForUpdateAsync).toHaveBeenCalled();
+    expect(result.current.status.isChecking).toBe(false);
+    expect(result.current.status.isAvailable).toBe(true);
+    expect(result.current.status.error).toBeNull();
+  });
+
+  it('checkForUpdate handles errors', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Updates = require('expo-updates');
+    (Updates.checkForUpdateAsync as jest.Mock).mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    const { result } = renderHook(() => useOtaUpdates());
+
+    await act(async () => {
+      await result.current.checkForUpdate();
+    });
+
+    expect(result.current.status.isChecking).toBe(false);
+    expect(result.current.status.error).toBe('Network error');
+  });
+
+  it('downloadAndApply does nothing when feature is disabled', async () => {
+    mockConfig.features.otaUpdates.enabled = false;
+
+    const { result } = renderHook(() => useOtaUpdates());
+    await act(async () => {
+      await result.current.downloadAndApply();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Updates = require('expo-updates');
+    expect(Updates.fetchUpdateAsync).not.toHaveBeenCalled();
+    expect(Updates.reloadAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/ota-updates/hooks/use-ota-updates.ts
+++ b/src/features/ota-updates/hooks/use-ota-updates.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+import { starterConfig } from '@/config/starter.config';
+
+export interface OtaUpdateStatus {
+  isChecking: boolean;
+  isDownloading: boolean;
+  isAvailable: boolean;
+  error: string | null;
+}
+
+export function useOtaUpdates() {
+  const [status, setStatus] = useState<OtaUpdateStatus>({
+    isChecking: false,
+    isDownloading: false,
+    isAvailable: false,
+    error: null,
+  });
+
+  const checkForUpdate = useCallback(async () => {
+    if (!starterConfig.features.otaUpdates.enabled) return;
+
+    try {
+      setStatus((s) => ({ ...s, isChecking: true, error: null }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Updates = require('expo-updates');
+      const result = await Updates.checkForUpdateAsync();
+      setStatus((s) => ({
+        ...s,
+        isChecking: false,
+        isAvailable: result.isAvailable,
+      }));
+    } catch (e) {
+      setStatus((s) => ({
+        ...s,
+        isChecking: false,
+        error: (e as Error).message,
+      }));
+    }
+  }, []);
+
+  const downloadAndApply = useCallback(async () => {
+    if (!starterConfig.features.otaUpdates.enabled) return;
+
+    try {
+      setStatus((s) => ({ ...s, isDownloading: true, error: null }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Updates = require('expo-updates');
+      await Updates.fetchUpdateAsync();
+      await Updates.reloadAsync();
+    } catch (e) {
+      setStatus((s) => ({
+        ...s,
+        isDownloading: false,
+        error: (e as Error).message,
+      }));
+    }
+  }, []);
+
+  return { status, checkForUpdate, downloadAndApply };
+}

--- a/src/features/ota-updates/index.ts
+++ b/src/features/ota-updates/index.ts
@@ -1,0 +1,2 @@
+export { useOtaUpdates } from './hooks/use-ota-updates';
+export type { OtaUpdateStatus } from './hooks/use-ota-updates';


### PR DESCRIPTION
## Summary
- Add OTA updates feature with useOtaUpdates hook
- Check for updates, download, and apply with status tracking
- Config-driven enable/disable, safe require() for Expo Go
- Add developer guide documentation

Closes #21

## Test plan
- [x] All 70 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Hook no-ops when feature disabled
- [x] Error handling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)