### PR TITLE
feat: add onboarding screens

### DIFF
--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -1,0 +1,89 @@
+# Onboarding
+
+## Overview
+
+The onboarding feature provides a swipeable multi-page introduction flow shown to users on their first app launch. It persists completion state so users only see it once, and can be toggled on/off via configuration.
+
+## Configuration
+
+Enable or disable onboarding in `src/config/starter.config.ts`:
+
+```typescript
+features: {
+  onboarding: { enabled: true },
+}
+```
+
+When `enabled` is `false`, `useOnboarding().shouldShow` will always return `false`.
+
+## Using the `useOnboarding` Hook
+
+```typescript
+import { useOnboarding } from '@/features/onboarding';
+
+function MyComponent() {
+  const { shouldShow, complete, reset, enabled } = useOnboarding();
+
+  // shouldShow - true when onboarding is enabled AND not yet completed
+  // complete() - marks onboarding as done (persisted via Zustand/MMKV)
+  // reset()    - resets onboarding state (useful during development)
+  // enabled    - whether the feature toggle is on
+}
+```
+
+## Using the `OnboardingScreen` Component
+
+`OnboardingScreen` renders the full onboarding flow with horizontal swiping, pagination dots, Skip button, and Next/Get Started button:
+
+```typescript
+import { OnboardingScreen } from '@/features/onboarding';
+
+// Render conditionally based on onboarding state
+function App() {
+  const { shouldShow } = useOnboarding();
+
+  if (shouldShow) {
+    return <OnboardingScreen />;
+  }
+
+  return <MainApp />;
+}
+```
+
+## Customizing Onboarding Pages
+
+Edit the `PAGES` array in `src/features/onboarding/components/onboarding-screen.tsx`:
+
+```typescript
+const PAGES = [
+  { title: 'Welcome', description: 'Get started with your new app.', icon: '\uD83D\uDC4B' },
+  { title: 'Discover', description: 'Explore features built for you.', icon: '\uD83D\uDD0D' },
+  { title: 'Ready', description: "You are all set. Let's go!", icon: '\uD83D\uDE80' },
+];
+```
+
+Each page accepts:
+- `title` - heading text
+- `description` - body text
+- `icon` (optional) - emoji or text displayed above the title
+
+For more control, use `OnboardingPage` directly:
+
+```typescript
+import { OnboardingPage } from '@/features/onboarding';
+
+<OnboardingPage title="Custom" description="Your custom page." icon="*" />
+```
+
+## Resetting Onboarding for Development
+
+Use the `reset()` function from `useOnboarding`:
+
+```typescript
+const { reset } = useOnboarding();
+reset(); // Onboarding will show again on next render
+```
+
+## Disabling the Feature
+
+Set `onboarding.enabled` to `false` in `src/config/starter.config.ts`. The `shouldShow` flag will always be `false` regardless of completion state.

--- a/src/features/onboarding/__tests__/onboarding.test.ts
+++ b/src/features/onboarding/__tests__/onboarding.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useOnboarding } from '../hooks/use-onboarding';
+import { starterConfig } from '@/config/starter.config';
+import { useAppStore } from '@/store/app-store';
+
+jest.mock('@/config/starter.config', () => ({
+  starterConfig: {
+    features: { onboarding: { enabled: true } },
+  },
+}));
+
+const mockSetHasCompletedOnboarding = jest.fn();
+
+jest.mock('@/store/app-store', () => ({
+  useAppStore: jest.fn(),
+}));
+
+const mockUseAppStore = useAppStore as unknown as jest.Mock;
+
+const mockConfig = starterConfig as {
+  features: { onboarding: { enabled: boolean } };
+};
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig.features.onboarding.enabled = true;
+    mockUseAppStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        hasCompletedOnboarding: false,
+        setHasCompletedOnboarding: mockSetHasCompletedOnboarding,
+      }),
+    );
+  });
+
+  it('returns shouldShow=true when enabled and not completed', () => {
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.shouldShow).toBe(true);
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('returns shouldShow=false when disabled', () => {
+    mockConfig.features.onboarding.enabled = false;
+
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.shouldShow).toBe(false);
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it('returns shouldShow=false when completed', () => {
+    mockUseAppStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        hasCompletedOnboarding: true,
+        setHasCompletedOnboarding: mockSetHasCompletedOnboarding,
+      }),
+    );
+
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.shouldShow).toBe(false);
+  });
+
+  it('complete() calls setHasCompletedOnboarding(true)', () => {
+    const { result } = renderHook(() => useOnboarding());
+    act(() => {
+      result.current.complete();
+    });
+    expect(mockSetHasCompletedOnboarding).toHaveBeenCalledWith(true);
+  });
+
+  it('reset() calls setHasCompletedOnboarding(false)', () => {
+    const { result } = renderHook(() => useOnboarding());
+    act(() => {
+      result.current.reset();
+    });
+    expect(mockSetHasCompletedOnboarding).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/features/onboarding/components/onboarding-page.tsx
+++ b/src/features/onboarding/components/onboarding-page.tsx
@@ -1,0 +1,21 @@
+import { View, Text } from 'react-native';
+
+interface OnboardingPageProps {
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+export function OnboardingPage({ title, description, icon }: OnboardingPageProps) {
+  return (
+    <View className="flex-1 items-center justify-center px-8">
+      {icon && <Text className="text-6xl mb-8">{icon}</Text>}
+      <Text className="text-2xl font-bold text-center mb-4 text-gray-900 dark:text-white">
+        {title}
+      </Text>
+      <Text className="text-base text-center text-gray-500 dark:text-gray-400">
+        {description}
+      </Text>
+    </View>
+  );
+}

--- a/src/features/onboarding/components/onboarding-screen.tsx
+++ b/src/features/onboarding/components/onboarding-screen.tsx
@@ -1,0 +1,69 @@
+import React, { useRef, useState } from 'react';
+import { View, Text, FlatList, Pressable, useWindowDimensions } from 'react-native';
+import { OnboardingPage } from './onboarding-page';
+import { useOnboarding } from '../hooks/use-onboarding';
+
+const PAGES = [
+  { title: 'Welcome', description: 'Get started with your new app.', icon: '\uD83D\uDC4B' },
+  { title: 'Discover', description: 'Explore features built for you.', icon: '\uD83D\uDD0D' },
+  { title: 'Ready', description: "You are all set. Let's go!", icon: '\uD83D\uDE80' },
+];
+
+export function OnboardingScreen() {
+  const { width } = useWindowDimensions();
+  const { complete } = useOnboarding();
+  const flatListRef = useRef<FlatList>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const isLastPage = currentIndex === PAGES.length - 1;
+
+  const handleNext = () => {
+    if (isLastPage) {
+      complete();
+    } else {
+      flatListRef.current?.scrollToIndex({ index: currentIndex + 1 });
+    }
+  };
+
+  return (
+    <View className="flex-1 bg-white dark:bg-black">
+      <FlatList
+        ref={flatListRef}
+        data={PAGES}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={(e) => {
+          const index = Math.round(e.nativeEvent.contentOffset.x / width);
+          setCurrentIndex(index);
+        }}
+        renderItem={({ item }) => (
+          <View style={{ width }}>
+            <OnboardingPage {...item} />
+          </View>
+        )}
+        keyExtractor={(_, i) => i.toString()}
+      />
+      {/* Pagination dots */}
+      <View className="flex-row justify-center mb-4">
+        {PAGES.map((_, i) => (
+          <View
+            key={i}
+            className={`w-2 h-2 rounded-full mx-1 ${i === currentIndex ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+          />
+        ))}
+      </View>
+      {/* Buttons */}
+      <View className="flex-row justify-between px-8 pb-12">
+        <Pressable onPress={complete}>
+          <Text className="text-base text-gray-500">Skip</Text>
+        </Pressable>
+        <Pressable onPress={handleNext} className="bg-blue-500 px-6 py-3 rounded-full">
+          <Text className="text-white text-base font-semibold">
+            {isLastPage ? 'Get Started' : 'Next'}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/src/features/onboarding/hooks/use-onboarding.ts
+++ b/src/features/onboarding/hooks/use-onboarding.ts
@@ -1,0 +1,19 @@
+import { starterConfig } from '@/config/starter.config';
+import { useAppStore } from '@/store/app-store';
+
+export function useOnboarding() {
+  const hasCompleted = useAppStore((s) => s.hasCompletedOnboarding);
+  const setCompleted = useAppStore((s) => s.setHasCompletedOnboarding);
+  const enabled = starterConfig.features.onboarding.enabled;
+
+  return {
+    /** Whether onboarding should be shown */
+    shouldShow: enabled && !hasCompleted,
+    /** Mark onboarding as complete */
+    complete: () => setCompleted(true),
+    /** Reset onboarding (for development) */
+    reset: () => setCompleted(false),
+    /** Whether onboarding feature is enabled */
+    enabled,
+  };
+}

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,3 @@
+export { useOnboarding } from './hooks/use-onboarding';
+export { OnboardingScreen } from './components/onboarding-screen';
+export { OnboardingPage } from './components/onboarding-page';


### PR DESCRIPTION
## Summary
- Add onboarding feature with swipeable page flow using FlatList
- Persist completion state via Zustand app store
- useOnboarding hook with shouldShow, complete, reset
- Config-driven enable/disable
- Add developer guide documentation

Closes #23

## Test plan
- [x] All 75 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Hook respects config toggle and completion state
- [x] Skip and complete actions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)