### PR TITLE
feat: integrate theme system into components and screens

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -3,16 +3,15 @@ import React from 'react';
 
 import { HapticTab } from '@/components/haptic-tab';
 import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useThemeColors } from '@/hooks/use-theme-colors';
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
+  const { tint } = useThemeColors();
 
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: tint,
         headerShown: false,
         tabBarButton: HapticTab,
       }}>

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -20,7 +20,7 @@ function QuickStartStep({
   return (
     <ThemedView className="gap-1 mb-4">
       <View className="flex-row items-center gap-2">
-        <View className="w-6 h-6 rounded-full bg-blue-500 items-center justify-center">
+        <View className="w-6 h-6 rounded-full bg-primary-500 items-center justify-center">
           <ThemedText className="text-white text-xs font-bold">{number}</ThemedText>
         </View>
         <ThemedText type="subtitle">{title}</ThemedText>
@@ -32,7 +32,7 @@ function QuickStartStep({
 
 function TechBadge({ label }: { label: string }) {
   return (
-    <View className="px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800">
+    <View className="px-3 py-1.5 rounded-lg bg-neutral-100 dark:bg-neutral-800">
       <ThemedText className="text-xs font-semibold">{label}</ThemedText>
     </View>
   );
@@ -58,7 +58,7 @@ export default function HomeScreen() {
         — enable what you need, swap providers without touching app code.
       </ThemedText>
 
-      <View className="bg-blue-500 p-4 rounded-xl my-2">
+      <View className="bg-primary-500 p-4 rounded-xl my-2">
         <ThemedText className="text-white font-bold text-center text-base">
           {basekitConfig.app.name} — Ready to build
         </ThemedText>
@@ -119,7 +119,7 @@ export default function HomeScreen() {
         </ThemedText>
       </QuickStartStep>
 
-      <View className="bg-gray-100 dark:bg-gray-800 p-4 rounded-xl mt-2">
+      <View className="bg-neutral-100 dark:bg-neutral-800 p-4 rounded-xl mt-2">
         <ThemedText className="text-sm text-center">
           Check out the{' '}
           <ThemedText type="defaultSemiBold" className="text-sm">

--- a/src/components/parallax-scroll-view.tsx
+++ b/src/components/parallax-scroll-view.tsx
@@ -8,8 +8,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { ThemedView } from '@/components/themed-view';
-import { useColorScheme } from '@/hooks/use-color-scheme';
-import { useThemeColor } from '@/hooks/use-theme-color';
+import { useThemeColors } from '@/hooks/use-theme-colors';
 
 const HEADER_HEIGHT = 250;
 
@@ -23,8 +22,7 @@ export default function ParallaxScrollView({
   headerImage,
   headerBackgroundColor,
 }: Props) {
-  const backgroundColor = useThemeColor({}, 'background');
-  const colorScheme = useColorScheme() ?? 'light';
+  const { background, mode } = useThemeColors();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollOffset(scrollRef);
   const headerAnimatedStyle = useAnimatedStyle(() => {
@@ -47,12 +45,12 @@ export default function ParallaxScrollView({
   return (
     <Animated.ScrollView
       ref={scrollRef}
-      style={{ backgroundColor, flex: 1 }}
+      style={{ backgroundColor: background, flex: 1 }}
       scrollEventThrottle={16}>
       <Animated.View
         style={[
           styles.header,
-          { backgroundColor: headerBackgroundColor[colorScheme] },
+          { backgroundColor: headerBackgroundColor[mode] },
           headerAnimatedStyle,
         ]}>
         {headerImage}

--- a/src/components/themed-text.tsx
+++ b/src/components/themed-text.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, type TextProps } from 'react-native';
 
 import { useThemeColor } from '@/hooks/use-theme-color';
+import { useThemeColors } from '@/hooks/use-theme-colors';
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
@@ -18,6 +19,7 @@ export function ThemedText({
   ...rest
 }: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  const { tint } = useThemeColors();
 
   return (
     <Text
@@ -27,7 +29,7 @@ export function ThemedText({
         type === 'title' ? styles.title : undefined,
         type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
         type === 'subtitle' ? styles.subtitle : undefined,
-        type === 'link' ? styles.link : undefined,
+        type === 'link' ? [styles.link, { color: tint }] : undefined,
         style,
       ]}
       className={className}
@@ -58,6 +60,5 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
   },
 });

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -4,12 +4,11 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useThemeColors } from '@/hooks/use-theme-colors';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const theme = useColorScheme() ?? 'light';
+  const { icon } = useThemeColors();
 
   return (
     <ThemedView>
@@ -21,7 +20,7 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
           name="chevron.right"
           size={18}
           weight="medium"
-          color={theme === 'light' ? Colors.light.icon : Colors.dark.icon}
+          color={icon}
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 

--- a/src/hooks/use-theme-color.ts
+++ b/src/hooks/use-theme-color.ts
@@ -1,8 +1,5 @@
-/**
- * Learn more about light and dark modes:
- * https://docs.expo.dev/guides/color-schemes/
- */
-
+import { useContext } from 'react';
+import { ThemeContext } from '@/features/theme/hooks/use-theme';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
@@ -10,12 +7,27 @@ export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
-  const colorFromProps = props[theme];
+  const themeCtx = useContext(ThemeContext);
+  const systemScheme = useColorScheme() ?? 'light';
+  const mode = themeCtx?.mode ?? systemScheme;
+  const colorFromProps = props[mode];
 
   if (colorFromProps) {
     return colorFromProps;
-  } else {
-    return Colors[theme][colorName];
   }
+
+  if (themeCtx) {
+    const surface = themeCtx.config.colors.surface[mode];
+    const mapping: Record<string, string> = {
+      text: mode === 'dark' ? '#ECEDEE' : '#11181C',
+      background: surface.background,
+      tint: themeCtx.config.colors.primary[500],
+      icon: themeCtx.config.colors.neutral[500],
+      tabIconDefault: themeCtx.config.colors.neutral[500],
+      tabIconSelected: themeCtx.config.colors.primary[500],
+    };
+    return mapping[colorName] ?? Colors[mode][colorName];
+  }
+
+  return Colors[mode][colorName];
 }

--- a/src/hooks/use-theme-colors.ts
+++ b/src/hooks/use-theme-colors.ts
@@ -1,0 +1,49 @@
+import { useContext } from 'react';
+import { ThemeContext } from '@/features/theme/hooks/use-theme';
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+/**
+ * Returns theme-aware colors. Uses the theme system when available,
+ * falls back to the base Colors constants when theme feature is disabled.
+ */
+export function useThemeColors() {
+  const themeCtx = useContext(ThemeContext);
+  const colorScheme = useColorScheme() ?? 'light';
+
+  if (themeCtx) {
+    const mode = themeCtx.mode;
+    const c = themeCtx.config.colors;
+    return {
+      text: c.surface[mode].background === '#ffffff' ? '#11181C' : '#ECEDEE',
+      background: c.surface[mode].background,
+      card: c.surface[mode].card,
+      border: c.surface[mode].border,
+      tint: c.primary[500],
+      icon: c.neutral[500],
+      primary: c.primary,
+      secondary: c.secondary,
+      accent: c.accent,
+      semantic: c.semantic,
+      mode,
+      isDark: mode === 'dark',
+    };
+  }
+
+  // Fallback to old Colors constants
+  const colors = Colors[colorScheme];
+  return {
+    text: colors.text,
+    background: colors.background,
+    card: colorScheme === 'dark' ? '#1e1e1e' : '#f9fafb',
+    border: colorScheme === 'dark' ? '#333' : '#e5e7eb',
+    tint: colors.tint,
+    icon: colors.icon,
+    primary: null,
+    secondary: null,
+    accent: null,
+    semantic: null,
+    mode: colorScheme,
+    isDark: colorScheme === 'dark',
+  };
+}


### PR DESCRIPTION
## Summary

Updates all existing components and screens to use the Basekit theme system instead of hardcoded colors.

**New:**
- `src/hooks/use-theme-colors.ts` — safe wrapper that uses `ThemeContext` when available, falls back to base `Colors` constants when theme feature is disabled

**Updated components:**
- `ThemedText` — link color now uses theme primary instead of hardcoded `#0a7ea4`
- `Collapsible` — icon color from theme tokens
- `ParallaxScrollView` — background from theme surface colors
- Tab layout — active tint from theme primary
- Home screen — `bg-blue-500` → `bg-primary-500`, `bg-gray-*` → `bg-neutral-*`
- `useThemeColor` — checks ThemeContext first, maps to theme tokens

**Backward compatible:** Works with or without the theme feature enabled.

## Test plan

- [x] 118/118 tests pass
- [x] TypeScript strict check passes
- [x] Lint clean
- [ ] Fresh clone with Bold theme → verify primary color appears in tab bar, step numbers, banner
- [ ] Fresh clone with "None" theme → verify fallback to base Colors works

🤖 Generated with [Claude Code](https://claude.com/claude-code)