### PR TITLE
feat: add agentic workflows — CLAUDE.md, settings, slash commands generation

### DIFF
--- a/docs/superpowers/plans/2026-03-26-agentic-workflows.md
+++ b/docs/superpowers/plans/2026-03-26-agentic-workflows.md
@@ -1,0 +1,1122 @@
+# Agentic Workflows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add agentic workflow file generation (CLAUDE.md, .claude/settings.json, slash commands) to the setup wizard, with a self-updating /evaluate command.
+
+**Architecture:** A registry defines all commands and feature sections as data. Three generator functions read the registry + setup answers to produce files. The setup wizard calls generators after stripping features. The /evaluate command is a self-contained markdown prompt that re-scans and regenerates.
+
+**Tech Stack:** TypeScript, fs-extra (already installed), @clack/prompts (already installed)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-agentic-workflows-design.md`
+
+**Branch:** `ft/agentic-workflows` (already created)
+
+---
+
+## File Map
+
+### New Files
+
+```
+setup/
+├── workflows/
+│   ├── registry.ts                    # Command + feature section definitions
+│   ├── generate-claude-md.ts          # Assembles CLAUDE.md from registry + answers
+│   ├── generate-settings.ts           # Builds .claude/settings.json
+│   ├── generate-commands.ts           # Copies selected command templates
+│   ├── __tests__/
+│   │   ├── generate-claude-md.test.ts
+│   │   └── generate-commands.test.ts
+│   └── templates/
+│       └── commands/
+│           ├── add-feature.md
+│           ├── new-screen.md
+│           ├── add-provider.md
+│           ├── run-checks.md
+│           ├── new-component.md
+│           ├── create-issue.md
+│           ├── create-branch.md
+│           └── evaluate.md
+```
+
+### Modified Files
+
+```
+setup/prompts.ts          # Add SetupAnswers fields + workflow/agent/command prompts
+setup/index.ts            # Add workflow generation step + --from YAML parsing
+```
+
+---
+
+## Task 1: Registry
+
+**Files:**
+- Create: `setup/workflows/registry.ts`
+
+- [ ] **Step 1: Create the registry with command definitions and feature sections**
+
+Create `setup/workflows/registry.ts` with all command definitions and feature section definitions. This is a data-only file — no logic, just structured definitions.
+
+```typescript
+import type { Manifest } from '../generator';
+
+export interface CommandDefinition {
+  id: string;
+  name: string;
+  description: string;
+  templateFile: string;
+  condition?: (selectedFeatures: Record<string, string>, manifest: Manifest) => boolean;
+}
+
+export interface FeatureSectionDefinition {
+  featureKey: string;
+  title: string;
+  files: string[];
+  patterns: string[];
+}
+
+export const commands: CommandDefinition[] = [
+  {
+    id: 'add-feature',
+    name: '/add-feature',
+    description: 'Scaffold a new feature module',
+    templateFile: 'commands/add-feature.md',
+  },
+  {
+    id: 'new-screen',
+    name: '/new-screen',
+    description: 'Create a new route/screen',
+    templateFile: 'commands/new-screen.md',
+  },
+  {
+    id: 'add-provider',
+    name: '/add-provider',
+    description: 'Add provider to existing feature',
+    templateFile: 'commands/add-provider.md',
+    condition: (selected, manifest) =>
+      Object.keys(selected).some((f) => {
+        const feature = manifest.features[f];
+        return feature && Object.keys(feature.providers).length > 0;
+      }),
+  },
+  {
+    id: 'run-checks',
+    name: '/run-checks',
+    description: 'Lint + typecheck + test',
+    templateFile: 'commands/run-checks.md',
+  },
+  {
+    id: 'new-component',
+    name: '/new-component',
+    description: 'Scaffold a component',
+    templateFile: 'commands/new-component.md',
+  },
+  {
+    id: 'create-issue',
+    name: '/create-issue',
+    description: 'Create a GitHub issue',
+    templateFile: 'commands/create-issue.md',
+  },
+  {
+    id: 'create-branch',
+    name: '/create-branch',
+    description: 'Create a feature branch',
+    templateFile: 'commands/create-branch.md',
+  },
+  {
+    id: 'evaluate',
+    name: '/evaluate',
+    description: 'Scan codebase and update workflow files',
+    templateFile: 'commands/evaluate.md',
+  },
+];
+
+export const featureSections: FeatureSectionDefinition[] = [
+  {
+    featureKey: 'auth',
+    title: 'Authentication',
+    files: ['src/services/auth.interface.ts', 'src/features/auth/auth-provider.tsx', 'src/features/auth/create-auth-service.ts'],
+    patterns: [
+      'Service interface at src/services/auth.interface.ts — all providers implement this',
+      'Add new providers in src/features/auth/providers/ following existing pattern',
+      'Auth state managed in AuthProvider via React Context',
+      'Token getter wired into API client automatically',
+    ],
+  },
+  {
+    featureKey: 'analytics',
+    title: 'Analytics',
+    files: ['src/services/analytics.interface.ts', 'src/features/analytics/analytics-provider.tsx', 'src/features/analytics/create-analytics-service.ts'],
+    patterns: [
+      'Track events via useAnalytics() hook',
+      'Add providers following amplify.ts pattern in providers/',
+    ],
+  },
+  {
+    featureKey: 'crash-reporting',
+    title: 'Crash Reporting',
+    files: ['src/services/crash-reporting.interface.ts', 'src/features/crash-reporting/crash-reporting-provider.tsx'],
+    patterns: [
+      'Capture errors via useCrashReporting() hook',
+      'Sentry provider at providers/sentry.ts',
+    ],
+  },
+  {
+    featureKey: 'notifications',
+    title: 'Push Notifications',
+    files: ['src/services/notifications.interface.ts', 'src/features/notifications/notification-provider.tsx'],
+    patterns: [
+      'Request permissions, send local notifications via useNotifications()',
+      'Add providers following amplify.ts pattern',
+    ],
+  },
+  {
+    featureKey: 'offline-storage',
+    title: 'Offline Storage',
+    files: ['src/services/storage.interface.ts', 'src/features/offline-storage/storage-provider.tsx', 'src/features/offline-storage/create-storage-service.ts'],
+    patterns: [
+      'Key-value storage via useStorage() hook',
+      'MMKV or AsyncStorage providers available',
+    ],
+  },
+  {
+    featureKey: 'i18n',
+    title: 'Internationalization',
+    files: ['src/features/i18n/i18n-provider.tsx', 'src/features/i18n/i18n.ts', 'src/features/i18n/locales/en.json'],
+    patterns: [
+      'Add translations in src/features/i18n/locales/',
+      'Use useAppTranslation() hook in components',
+    ],
+  },
+  {
+    featureKey: 'forms',
+    title: 'Forms & Validation',
+    files: ['src/features/forms/hooks/use-app-form.ts', 'src/features/forms/components/form-input.tsx', 'src/features/forms/schemas/common.ts'],
+    patterns: [
+      'Zod schemas in schemas/, form components in components/',
+      'Use useAppForm(schema) hook for form state',
+    ],
+  },
+  {
+    featureKey: 'security',
+    title: 'Security',
+    files: ['src/features/security/security-provider.tsx', 'src/features/security/hooks/use-biometrics.ts', 'src/features/security/hooks/use-app-lock.ts', 'src/features/security/config/pinning.ts'],
+    patterns: [
+      'Biometrics via useBiometrics() hook',
+      'Secure storage via useSecureStorage() hook',
+      'App lock via useAppLock() hook',
+      'SSL pinning config in config/pinning.ts',
+    ],
+  },
+  {
+    featureKey: 'theme',
+    title: 'Theme System',
+    files: ['src/config/theme.config.ts', 'src/features/theme/hooks/use-theme.ts', 'src/features/theme/utils/generate-tailwind.ts'],
+    patterns: [
+      'Edit theme.config.ts to change design tokens — no component changes needed',
+      'useTheme() hook for runtime values (colors, spacing, shadows)',
+      'Tailwind classes auto-generated from tokens (bg-primary-500, etc.)',
+      'useThemeColors() is a safe wrapper that falls back when theme is disabled',
+    ],
+  },
+  {
+    featureKey: 'onboarding',
+    title: 'Onboarding',
+    files: ['src/features/onboarding/hooks/use-onboarding.ts', 'src/features/onboarding/components/onboarding-screen.tsx'],
+    patterns: [
+      'Completion persisted in Zustand store',
+      'Check useOnboarding().shouldShow to decide whether to show onboarding',
+    ],
+  },
+  {
+    featureKey: 'deep-linking',
+    title: 'Deep Linking',
+    files: ['src/features/deep-linking/hooks/use-deep-link.ts', 'src/features/deep-linking/utils/build-deep-link.ts'],
+    patterns: [
+      'Monitor incoming URLs via useDeepLink() hook',
+      'Build links with buildDeepLink() utility',
+    ],
+  },
+  {
+    featureKey: 'ota-updates',
+    title: 'OTA Updates',
+    files: ['src/features/ota-updates/hooks/use-ota-updates.ts'],
+    patterns: ['Check and apply updates via useOtaUpdates() hook'],
+  },
+  {
+    featureKey: 'splash-app-icon',
+    title: 'Splash Screen & App Icon',
+    files: ['src/features/splash-app-icon/hooks/use-splash-screen.ts'],
+    patterns: ['Control splash visibility via useSplashScreen() hook'],
+  },
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add setup/workflows/registry.ts
+git commit -m "feat: add agentic workflows registry with command and feature definitions"
+```
+
+---
+
+## Task 2: CLAUDE.md Generator (TDD)
+
+**Files:**
+- Create: `setup/workflows/generate-claude-md.ts`
+- Create: `setup/workflows/__tests__/generate-claude-md.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `setup/workflows/__tests__/generate-claude-md.test.ts`:
+
+```typescript
+import { generateClaudeMd } from '../generate-claude-md';
+
+describe('generateClaudeMd', () => {
+  const baseAnswers = {
+    appName: 'test-app',
+    bundleId: 'com.test.app',
+    scheme: 'testapp',
+    features: { auth: 'amplify', i18n: '', theme: 'minimal' } as Record<string, string>,
+  };
+
+  it('should generate minimal CLAUDE.md for manual mode', () => {
+    const result = generateClaudeMd({
+      ...baseAnswers,
+      workflow: 'manual' as const,
+    });
+
+    expect(result).toContain('# test-app');
+    expect(result).toContain('## Tech Stack');
+    expect(result).toContain('## Commands');
+    // Should NOT contain agentic sections
+    expect(result).not.toContain('## Code Style');
+    expect(result).not.toContain('## Feature Guide');
+  });
+
+  it('should generate full CLAUDE.md for agentic mode', () => {
+    const result = generateClaudeMd({
+      ...baseAnswers,
+      workflow: 'agentic' as const,
+    });
+
+    expect(result).toContain('# test-app');
+    expect(result).toContain('## Code Style');
+    expect(result).toContain('## Feature Architecture');
+    expect(result).toContain('## Feature Guide');
+    expect(result).toContain('### Authentication');
+    expect(result).toContain('### Internationalization');
+    expect(result).toContain('### Theme System');
+  });
+
+  it('should only include guides for selected features', () => {
+    const result = generateClaudeMd({
+      appName: 'test-app',
+      bundleId: 'com.test.app',
+      scheme: 'testapp',
+      features: { auth: 'amplify' },
+      workflow: 'agentic' as const,
+    });
+
+    expect(result).toContain('### Authentication');
+    expect(result).not.toContain('### Theme System');
+    expect(result).not.toContain('### Internationalization');
+  });
+
+  it('should include provider info in feature guides', () => {
+    const result = generateClaudeMd({
+      ...baseAnswers,
+      workflow: 'agentic' as const,
+    });
+
+    expect(result).toContain('amplify');
+    expect(result).toContain('src/services/auth.interface.ts');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — should FAIL**
+
+```bash
+pnpm test -- setup/workflows/__tests__/generate-claude-md.test.ts --no-coverage
+```
+
+- [ ] **Step 3: Implement**
+
+Create `setup/workflows/generate-claude-md.ts`:
+
+```typescript
+import { featureSections } from './registry';
+
+interface GenerateOptions {
+  appName: string;
+  bundleId: string;
+  scheme: string;
+  features: Record<string, string>;
+  workflow: 'agentic' | 'manual';
+}
+
+export function generateClaudeMd(options: GenerateOptions): string {
+  const { appName, features, workflow } = options;
+  const sections: string[] = [];
+
+  // Header
+  sections.push(`# ${appName}\n`);
+
+  // Tech stack (always included)
+  sections.push(generateTechStack(features));
+
+  // Project structure (always included)
+  sections.push(generateProjectStructure(features));
+
+  // Commands (always included)
+  sections.push(generateCommands());
+
+  if (workflow === 'agentic') {
+    sections.push(generatePathAliases());
+    sections.push(generateCodeStyle());
+    sections.push(generateComponentPatterns());
+    sections.push(generateRouting());
+    sections.push(generateGitWorkflow());
+    sections.push(generateFeatureArchitecture());
+    sections.push(generateFeatureGuide(features));
+  }
+
+  return sections.join('\n');
+}
+
+function generateTechStack(features: Record<string, string>): string {
+  const lines = [
+    '## Tech Stack',
+    '- **Runtime**: Expo SDK 54 with React Native 0.81',
+    '- **Language**: TypeScript (strict mode)',
+    '- **Navigation**: expo-router (file-based routing)',
+    '- **Styling**: NativeWind v4 + TailwindCSS 3.4',
+    '- **Package Manager**: pnpm',
+  ];
+
+  if ('theme' in features) lines.push('- **Theming**: Design tokens via theme.config.ts');
+  if ('auth' in features) lines.push(`- **Auth**: ${features.auth || 'configured'}`);
+  if ('analytics' in features) lines.push(`- **Analytics**: ${features.analytics || 'configured'}`);
+  if ('crash-reporting' in features) lines.push(`- **Crash Reporting**: ${features['crash-reporting'] || 'configured'}`);
+  if ('i18n' in features) lines.push('- **i18n**: i18next + react-i18next');
+  if ('forms' in features) lines.push('- **Forms**: React Hook Form + Zod');
+  if ('security' in features) lines.push('- **Security**: expo-local-authentication + expo-secure-store');
+  if ('offline-storage' in features) lines.push(`- **Storage**: ${features['offline-storage'] || 'configured'}`);
+
+  return lines.join('\n') + '\n';
+}
+
+function generateProjectStructure(features: Record<string, string>): string {
+  const featureDirs = Object.keys(features)
+    .filter((f) => f !== 'theme')
+    .map((f) => `│   ├── ${f}/`)
+    .join('\n');
+
+  const themeDir = 'theme' in features ? '\n│   ├── theme/' : '';
+
+  return `## Project Structure
+\`\`\`
+src/
+├── app/              # Expo Router file-based routes
+├── components/       # Reusable components
+│   └── ui/           # Base UI components
+├── config/           # basekit.config.ts${themeDir ? ', theme.config.ts' : ''}
+├── features/         # Feature modules
+${featureDirs}${themeDir}
+├── hooks/            # Shared React hooks
+├── lib/              # Library wrappers (api, providers)
+├── services/         # Service interfaces
+├── store/            # Zustand stores
+└── types/            # Shared TypeScript types
+\`\`\`
+`;
+}
+
+function generateCommands(): string {
+  return `## Commands
+- \`pnpm start\` — Start Expo dev server
+- \`pnpm android\` — Start on Android
+- \`pnpm ios\` — Start on iOS
+- \`pnpm web\` — Start on web
+- \`pnpm lint\` — Run ESLint
+- \`pnpm typecheck\` — TypeScript type checking
+- \`pnpm test\` — Run unit tests
+- \`pnpm test:coverage\` — Test coverage report
+`;
+}
+
+function generatePathAliases(): string {
+  return `## Path Aliases
+- \`@/*\` → \`src/*\`
+- \`@assets/*\` → \`assets/*\`
+`;
+}
+
+function generateCodeStyle(): string {
+  return `## Code Style
+- Use TypeScript with strict mode — no \`any\` types
+- Use NativeWind className for styling (not StyleSheet.create)
+- Use kebab-case for file names (e.g., \`my-component.tsx\`)
+- Use PascalCase for component names
+- Use path aliases (\`@/\`, \`@assets/\`) for imports — never relative paths like \`../../\`
+- Functional components with hooks only — no class components
+- Export components as named exports (not default)
+`;
+}
+
+function generateComponentPatterns(): string {
+  return `## Component Patterns
+- Place reusable components in \`src/components/\`
+- Place base/primitive UI components in \`src/components/ui/\`
+- Place screen-specific components alongside their route files or in a \`_components/\` subfolder
+- Export components as named exports
+`;
+}
+
+function generateRouting(): string {
+  return `## Routing
+- All routes live in \`src/app/\` following expo-router conventions
+- Use route groups \`(groupName)\` for layout organization
+- Shared layouts use \`_layout.tsx\` files
+`;
+}
+
+function generateGitWorkflow(): string {
+  return `## Git Workflow
+- Branch naming: \`ft/<feature-name>\`, \`fix/<bug-name>\`, \`refactor/<description>\`
+- Commit messages: conventional commits (feat:, fix:, refactor:, docs:, chore:)
+- Always create feature branches — never commit directly to \`main\`
+- Run \`pnpm lint\` before committing
+`;
+}
+
+function generateFeatureArchitecture(): string {
+  return `## Feature Architecture
+Each feature follows this pattern:
+\`\`\`
+src/features/<name>/
+├── <name>-provider.tsx      # React context provider (with feature toggle)
+├── create-<name>-service.ts # Factory with dynamic imports (if swappable providers)
+├── no-op-<name>.ts          # Fallback when feature disabled
+├── hooks/                   # Public hooks consumed by the app
+├── providers/               # Swappable provider implementations
+└── __tests__/               # Unit tests
+\`\`\`
+`;
+}
+
+function generateFeatureGuide(features: Record<string, string>): string {
+  const sections = featureSections
+    .filter((s) => s.featureKey in features)
+    .map((s) => {
+      const provider = features[s.featureKey];
+      const lines = [`### ${s.title}`, ''];
+      lines.push('**Key files:**');
+      for (const f of s.files) {
+        lines.push(`- \`${f}\``);
+      }
+      lines.push('');
+      if (provider) {
+        lines.push(`**Provider:** ${provider}`);
+        lines.push('');
+      }
+      lines.push('**Patterns:**');
+      for (const p of s.patterns) {
+        lines.push(`- ${p}`);
+      }
+      return lines.join('\n');
+    });
+
+  return `## Feature Guide\n\n${sections.join('\n\n')}\n`;
+}
+```
+
+- [ ] **Step 4: Run test — should PASS**
+
+```bash
+pnpm test -- setup/workflows/__tests__/generate-claude-md.test.ts --no-coverage
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add setup/workflows/generate-claude-md.ts setup/workflows/__tests__/generate-claude-md.test.ts
+git commit -m "feat: add CLAUDE.md generator with manual/agentic modes"
+```
+
+---
+
+## Task 3: Settings and Commands Generators
+
+**Files:**
+- Create: `setup/workflows/generate-settings.ts`
+- Create: `setup/workflows/generate-commands.ts`
+- Create: `setup/workflows/__tests__/generate-commands.test.ts`
+
+- [ ] **Step 1: Create settings generator**
+
+Create `setup/workflows/generate-settings.ts`:
+
+```typescript
+export function generateSettings(): object {
+  return {
+    permissions: {
+      allow: [
+        'Bash(pnpm lint)',
+        'Bash(pnpm test)',
+        'Bash(pnpm test:*)',
+        'Bash(pnpm typecheck)',
+        'Bash(pnpm start)',
+        'Bash(pnpm start:*)',
+        'Bash(git status*)',
+        'Bash(git log*)',
+        'Bash(git diff*)',
+        'Bash(git branch*)',
+        'Bash(git checkout*)',
+        'Bash(git add*)',
+        'Bash(git commit*)',
+        'Bash(git push*)',
+        'Bash(git pull*)',
+        'Bash(git fetch*)',
+        'Bash(gh issue*)',
+        'Bash(gh pr*)',
+      ],
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Write failing test for commands generator**
+
+Create `setup/workflows/__tests__/generate-commands.test.ts`:
+
+```typescript
+import { getAvailableCommands } from '../generate-commands';
+import { commands } from '../registry';
+
+describe('getAvailableCommands', () => {
+  const mockManifest = {
+    features: {
+      auth: { providers: { amplify: {} }, sharedFiles: [], sharedDependencies: {}, requires: [], enhancedBy: [], providerChain: null, routes: [], displayName: 'Auth', description: '', category: 'auth' },
+      i18n: { providers: {}, sharedFiles: [], sharedDependencies: {}, requires: [], enhancedBy: [], providerChain: null, routes: [], displayName: 'i18n', description: '', category: 'i18n' },
+    },
+    categories: {},
+  };
+
+  it('should return all commands without conditions when features have providers', () => {
+    const selected = { auth: 'amplify', i18n: '' };
+    const selectedCommands = commands.map((c) => c.id);
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result.map((c) => c.id)).toContain('add-provider');
+    expect(result.map((c) => c.id)).toContain('add-feature');
+  });
+
+  it('should exclude add-provider when no features have providers', () => {
+    const selected = { i18n: '' };
+    const selectedCommands = commands.map((c) => c.id);
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result.map((c) => c.id)).not.toContain('add-provider');
+  });
+
+  it('should only return user-selected commands', () => {
+    const selected = { auth: 'amplify' };
+    const selectedCommands = ['run-checks', 'evaluate'];
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['run-checks', 'evaluate']);
+  });
+});
+```
+
+- [ ] **Step 3: Run test — should FAIL**
+
+```bash
+pnpm test -- setup/workflows/__tests__/generate-commands.test.ts --no-coverage
+```
+
+- [ ] **Step 4: Implement commands generator**
+
+Create `setup/workflows/generate-commands.ts`:
+
+```typescript
+import { commands } from './registry';
+import type { CommandDefinition } from './registry';
+import type { Manifest } from '../generator';
+
+export function getAvailableCommands(
+  selectedCommandIds: string[],
+  selectedFeatures: Record<string, string>,
+  manifest: Manifest,
+): CommandDefinition[] {
+  return commands.filter((cmd) => {
+    // Must be selected by the user
+    if (!selectedCommandIds.includes(cmd.id)) return false;
+
+    // Must pass condition check (if defined)
+    if (cmd.condition && !cmd.condition(selectedFeatures, manifest)) return false;
+
+    return true;
+  });
+}
+```
+
+- [ ] **Step 5: Run test — should PASS**
+
+```bash
+pnpm test -- setup/workflows/__tests__/generate-commands.test.ts --no-coverage
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add setup/workflows/generate-settings.ts setup/workflows/generate-commands.ts setup/workflows/__tests__/generate-commands.test.ts
+git commit -m "feat: add settings and commands generators"
+```
+
+---
+
+## Task 4: Command Templates
+
+**Files:**
+- Create: `setup/workflows/templates/commands/add-feature.md`
+- Create: `setup/workflows/templates/commands/new-screen.md`
+- Create: `setup/workflows/templates/commands/add-provider.md`
+- Create: `setup/workflows/templates/commands/run-checks.md`
+- Create: `setup/workflows/templates/commands/new-component.md`
+- Create: `setup/workflows/templates/commands/create-issue.md`
+- Create: `setup/workflows/templates/commands/create-branch.md`
+- Create: `setup/workflows/templates/commands/evaluate.md`
+
+- [ ] **Step 1: Create all 8 command templates**
+
+Each template is a markdown file that Claude Code reads as a slash command prompt. Create each file with the full content as specified in the spec (Section 5). The templates should be self-contained instructions that Claude Code can follow.
+
+For `/add-feature`:
+```markdown
+Create a new feature module following the Basekit pattern.
+
+Ask the user for:
+1. Feature name (kebab-case)
+2. Does it need swappable providers? (Y/n)
+3. Does it need a provider chain entry in app-providers.tsx? (Y/n)
+
+Then scaffold these files:
+- src/features/{name}/{name}-provider.tsx — React context provider
+- src/features/{name}/hooks/use-{name}.ts — Public hook
+- src/features/{name}/__tests__/ — Test directory
+- src/features/{name}/index.ts — Barrel export
+
+If providers needed, also create:
+- src/features/{name}/create-{name}-service.ts — Factory with dynamic imports
+- src/features/{name}/no-op-{name}.ts — No-op fallback
+- src/features/{name}/providers/ — Provider directory
+- src/services/{name}.interface.ts — Service contract
+- src/types/{name}.types.ts — Types
+
+If provider chain needed:
+- Add the provider to src/lib/providers/app-providers.tsx
+- Add feature config to src/config/basekit.config.ts
+
+Follow TDD — write tests first, then implementation.
+Use path aliases (@/) for all imports.
+Use NativeWind className for any UI.
+After scaffolding, run /evaluate to update CLAUDE.md.
+```
+
+For `/new-screen`:
+```markdown
+Create a new screen/route in the app.
+
+Ask the user for:
+1. Screen name (kebab-case)
+2. Route group: (tabs), (auth), or root level
+3. Does it need its own layout file? (Y/n)
+
+Create the screen file at: src/app/{group}/{screen-name}.tsx
+
+Use this pattern:
+- Import ThemedView, ThemedText from @/components/
+- Use NativeWind className for all styling
+- Use path aliases for imports
+- Export as default (required by expo-router)
+
+If layout needed, also create: src/app/{group}/_layout.tsx
+```
+
+For `/add-provider`:
+```markdown
+Add a new provider implementation to an existing feature.
+
+Ask the user for:
+1. Which feature? (list features in src/features/ that have a providers/ directory)
+2. Provider name (kebab-case)
+
+Steps:
+1. Read the service interface at src/services/{feature}.interface.ts
+2. Create src/features/{feature}/providers/{provider}.ts implementing the full interface
+3. Add the provider to the dynamic import map in create-{feature}-service.ts
+4. Add the provider name to the union type in src/config/basekit.config.ts
+5. Write unit tests for the new provider in src/features/{feature}/__tests__/
+6. Run pnpm lint && pnpm typecheck && pnpm test
+7. Run /evaluate to update CLAUDE.md with the new provider
+```
+
+For `/run-checks`:
+```markdown
+Run the full check suite and report results.
+
+Execute in sequence:
+1. pnpm lint
+2. pnpm typecheck
+3. pnpm test --no-coverage
+
+Report pass/fail for each step. If any step fails, investigate the errors and suggest fixes before moving to the next step.
+```
+
+For `/new-component`:
+```markdown
+Create a new reusable component.
+
+Ask the user for:
+1. Component name (PascalCase)
+2. Location: src/components/ui/ (base component) or src/components/ (shared component)
+
+Create the file at: src/components/{ui/}{kebab-case-name}.tsx
+
+Follow these patterns:
+- Use NativeWind className for all styling
+- Use useThemeColors() for dynamic theme values if needed
+- Export as a named export (not default)
+- Include a TypeScript props interface: {Name}Props
+- Use path aliases (@/) for imports
+```
+
+For `/create-issue`:
+```markdown
+Create a GitHub issue for tracking work.
+
+Ask the user for:
+1. Issue title
+2. Description
+3. Labels: bug, feature, enhancement, docs (can select multiple)
+
+Run:
+```
+gh issue create --title "{title}" --body "{description}" --label "{labels}"
+```
+
+If the `gh` CLI is not installed, format the issue as markdown output the user can copy-paste into GitHub's web UI.
+```
+
+For `/create-branch`:
+```markdown
+Create a feature branch following the project's naming convention.
+
+Ask the user for:
+1. Type: feature, fix, or refactor
+2. Short description (will be converted to kebab-case)
+
+Map type to prefix:
+- feature → ft/
+- fix → fix/
+- refactor → refactor/
+
+Run:
+```
+git checkout main
+git pull origin main
+git checkout -b {prefix}{description-in-kebab-case}
+```
+```
+
+For `/evaluate` — this is the longest template because it embeds all generation rules:
+```markdown
+Scan the codebase and regenerate workflow files to match the current project state.
+
+## What to scan
+
+1. **Features:** List all directories in src/features/
+2. **Providers:** For each feature, list files in src/features/{name}/providers/
+3. **Config:** Read src/config/basekit.config.ts — extract enabled features and providers
+4. **Components:** List all .tsx files in src/components/ and src/components/ui/
+5. **Hooks:** List all .ts files in src/hooks/
+6. **Routes:** List all route files in src/app/ (recursively, including route groups)
+7. **Dependencies:** Read package.json — extract dependency names
+8. **Scripts:** Read package.json scripts section
+9. **Commands:** List existing .md files in .claude/commands/
+
+## How to regenerate CLAUDE.md
+
+Rewrite CLAUDE.md with these sections:
+
+1. **Header:** `# {app name from basekit.config.ts}`
+2. **Tech Stack:** List runtime, language, navigation, styling, and only technologies for features that exist in src/features/
+3. **Project Structure:** Show actual src/ directory structure
+4. **Commands:** List all pnpm scripts from package.json
+5. **Path Aliases:** @/* → src/*, @assets/* → assets/*
+6. **Code Style:** TypeScript strict, NativeWind className, kebab-case files, PascalCase components, path aliases, named exports
+7. **Component Patterns:** src/components/, src/components/ui/, _components/ subfolders
+8. **Routing:** expo-router conventions, route groups, _layout.tsx
+9. **Git Workflow:** ft/, fix/, refactor/ branches, conventional commits
+10. **Feature Architecture:** Show the standard feature module pattern
+11. **Feature Guide:** For each feature directory that exists in src/features/, add a section with:
+    - Key files (provider, hooks, service interface)
+    - The active provider (from config or by checking which provider files exist)
+    - Development patterns (how to extend, how to use hooks)
+
+## How to manage commands
+
+Check each command in .claude/commands/:
+- If /add-provider.md exists but no feature has a providers/ directory → delete it
+- If features with providers exist but /add-provider.md is missing → create it
+
+Do NOT add or remove other commands — they are user-selected.
+
+## After regenerating
+
+1. Show a summary of what changed
+2. Commit: `git add CLAUDE.md .claude/ && git commit -m "chore: update workflow files via /evaluate"`
+```
+
+- [ ] **Step 2: Commit all templates**
+
+```bash
+git add setup/workflows/templates/
+git commit -m "feat: add all 8 slash command templates"
+```
+
+---
+
+## Task 5: Setup Wizard Integration
+
+**Files:**
+- Modify: `setup/prompts.ts`
+- Modify: `setup/index.ts`
+
+- [ ] **Step 1: Update SetupAnswers and add workflow prompts**
+
+Modify `setup/prompts.ts`:
+
+Add to `SetupAnswers` interface:
+```typescript
+workflow: 'agentic' | 'manual';
+agents: string[];
+commands: string[];
+```
+
+Add workflow prompts after the dependency validation block in `runInteractivePrompts`, before the `return`:
+
+```typescript
+// Workflow mode
+const workflow = await p.select({
+  message: 'Development workflow',
+  options: [
+    { value: 'agentic', label: 'Agentic', hint: 'Generate AI agent workflow files' },
+    { value: 'manual', label: 'Manual', hint: 'Minimal project context only' },
+  ],
+});
+
+if (p.isCancel(workflow)) {
+  p.cancel('Setup cancelled.');
+  process.exit(0);
+}
+
+let agents: string[] = [];
+let selectedCommands: string[] = [];
+
+if (workflow === 'agentic') {
+  const agentChoice = await p.multiselect({
+    message: 'Select agents',
+    options: [
+      { value: 'claude-code', label: 'Claude Code', hint: 'CLAUDE.md + .claude/ commands' },
+    ],
+    required: true,
+  });
+
+  if (p.isCancel(agentChoice)) {
+    p.cancel('Setup cancelled.');
+    process.exit(0);
+  }
+  agents = agentChoice as string[];
+
+  if (agents.includes('claude-code')) {
+    const { commands: availableCommands } = await import('./workflows/registry');
+    const filteredCommands = availableCommands.filter(
+      (cmd) => !cmd.condition || cmd.condition(features, manifest),
+    );
+
+    const commandChoice = await p.multiselect({
+      message: 'Select workflow commands',
+      options: filteredCommands.map((cmd) => ({
+        value: cmd.id,
+        label: cmd.name,
+        hint: cmd.description,
+      })),
+      required: false,
+    });
+
+    if (p.isCancel(commandChoice)) {
+      p.cancel('Setup cancelled.');
+      process.exit(0);
+    }
+    selectedCommands = commandChoice as string[];
+  }
+}
+```
+
+Update the return statement to include the new fields:
+```typescript
+return {
+  // ...existing fields
+  workflow: workflow as 'agentic' | 'manual',
+  agents,
+  commands: selectedCommands,
+};
+```
+
+Update `getQuickDefaults()` to include:
+```typescript
+workflow: 'manual' as const,
+agents: [],
+commands: [],
+```
+
+- [ ] **Step 2: Add workflow generation step to setup/index.ts**
+
+Add imports at the top of `setup/index.ts`:
+```typescript
+import { generateClaudeMd } from './workflows/generate-claude-md';
+import { generateSettings } from './workflows/generate-settings';
+import { getAvailableCommands } from './workflows/generate-commands';
+```
+
+Add the `--from` YAML parsing for workflow fields (in the `fromFile` branch, after setting `answers.features`):
+```typescript
+answers.workflow = config.workflow ?? 'manual';
+answers.agents = config.agents ?? [];
+answers.commands = config.commands ?? [];
+```
+
+Add workflow generation step between theme handling (current step 7) and pnpm install (current step 8). Insert this block:
+
+```typescript
+// Step 8: Generate workflow files
+s.start('Generating workflow files');
+const claudeMd = generateClaudeMd({
+  appName: answers.appName,
+  bundleId: answers.bundleId,
+  scheme: answers.scheme,
+  features: answers.features,
+  workflow: answers.workflow,
+});
+await fs.writeFile(path.join(PROJECT_ROOT, 'CLAUDE.md'), claudeMd);
+
+if (answers.workflow === 'agentic' && answers.agents.includes('claude-code')) {
+  // Write settings.json
+  await fs.ensureDir(path.join(PROJECT_ROOT, '.claude'));
+  await fs.writeJson(
+    path.join(PROJECT_ROOT, '.claude', 'settings.json'),
+    generateSettings(),
+    { spaces: 2 },
+  );
+
+  // Write selected command files
+  const manifest: Manifest = await fs.readJson(path.join(PROJECT_ROOT, 'basekit.manifest.json')).catch(() => ({ features: {}, categories: {} }));
+  const availableCommands = getAvailableCommands(answers.commands, answers.features, manifest);
+  const commandsDir = path.join(PROJECT_ROOT, '.claude', 'commands');
+  await fs.ensureDir(commandsDir);
+
+  for (const cmd of availableCommands) {
+    const templatePath = path.join(__dirname, 'workflows', 'templates', cmd.templateFile);
+    if (await fs.pathExists(templatePath)) {
+      const content = await fs.readFile(templatePath, 'utf-8');
+      await fs.writeFile(path.join(commandsDir, `${cmd.id}.md`), content);
+    }
+  }
+}
+s.stop(color.green('Generated workflow files'));
+```
+
+Note: The manifest might already be deleted at this point in some code paths. Read it before it's stripped, or read it earlier in the flow and pass it through. Since the manifest is loaded at the top of `main()` and stored in `const manifest`, just use that variable directly.
+
+- [ ] **Step 3: Update dry-run output to include workflow info**
+
+In the dry-run block, add:
+```typescript
+`Workflow: ${answers.workflow}`,
+`Agents: ${answers.agents.join(', ') || 'none'}`,
+`Commands: ${answers.commands.join(', ') || 'none'}`,
+```
+
+- [ ] **Step 4: Run typecheck and all tests**
+
+```bash
+pnpm typecheck && pnpm test --no-coverage
+```
+
+Fix any issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add setup/prompts.ts setup/index.ts
+git commit -m "feat: integrate workflow generation into setup wizard"
+```
+
+---
+
+## Task 6: Integration Test and Verification
+
+- [ ] **Step 1: Run lint**
+
+```bash
+pnpm lint
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+pnpm test --no-coverage
+```
+
+- [ ] **Step 4: Test dry-run with workflow**
+
+```bash
+pnpm run setup -- --dry-run --quick
+```
+
+Should show `Workflow: manual` in dry-run output.
+
+- [ ] **Step 5: Final commit if fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address integration issues"
+```
+
+---
+
+## Summary
+
+| Task | Description | Steps |
+|------|-------------|-------|
+| 1 | Registry (data definitions) | 2 |
+| 2 | CLAUDE.md generator (TDD) | 5 |
+| 3 | Settings + commands generators (TDD) | 6 |
+| 4 | Command templates (8 files) | 2 |
+| 5 | Setup wizard integration | 5 |
+| 6 | Integration test | 5 |
+| **Total** | | **25 steps** |

--- a/docs/superpowers/specs/2026-03-26-agentic-workflows-design.md
+++ b/docs/superpowers/specs/2026-03-26-agentic-workflows-design.md
@@ -1,0 +1,334 @@
+# Agentic Workflows Feature Design
+
+## Overview
+
+Generate AI agent workflow files (CLAUDE.md, settings, slash commands) during `pnpm run setup` based on the developer's selected features, providers, and preferences. The generated files give AI coding agents full project context and reusable commands tailored to the actual codebase — no dead references to stripped features.
+
+A self-updating `/evaluate` command keeps workflow files in sync as the project evolves.
+
+**Scope:** Claude Code workflows only (Phase 1). Cursor, Gemini, and other agents planned for future phases.
+
+---
+
+## 1. Setup Wizard Flow
+
+### New Prompts
+
+Added after feature selection, before the generation steps:
+
+```
+◇  Development workflow
+   ● Agentic — Generate AI agent workflow files
+   ○ Manual — Minimal project context only
+
+◇  Select agent (if agentic)
+   ◼ Claude Code
+
+◇  Select workflow commands (if Claude Code)
+   ◼ /add-feature — Scaffold a new feature module
+   ◼ /new-screen — Create a new route/screen
+   ◼ /add-provider — Add provider to existing feature
+   ◼ /run-checks — Lint + typecheck + test
+   ◼ /new-component — Scaffold a component
+   ◼ /create-issue — Create a GitHub issue
+   ◼ /create-branch — Create a feature branch
+   ◼ /evaluate — Scan codebase and update workflow files
+```
+
+### SetupAnswers Extension
+
+```typescript
+interface SetupAnswers {
+  // ... existing fields
+  workflow: 'agentic' | 'manual';
+  agents: string[];              // ['claude-code'] for now
+  commands: string[];            // ['add-feature', 'new-screen', ...]
+}
+```
+
+### What Gets Generated
+
+| Mode | CLAUDE.md | .claude/settings.json | .claude/commands/ |
+|------|-----------|----------------------|-------------------|
+| Manual | Minimal (tech stack, structure, commands) | No | No |
+| Agentic + Claude Code | Full (context + conventions + feature guides) | Yes | Selected commands |
+
+---
+
+## 2. File Structure
+
+### Generated Files (in scaffolded project)
+
+```
+project/
+├── CLAUDE.md                          # Full or minimal based on mode
+├── .claude/
+│   ├── settings.json                  # Pre-configured permissions
+│   └── commands/
+│       ├── add-feature.md
+│       ├── new-screen.md
+│       ├── add-provider.md
+│       ├── run-checks.md
+│       ├── new-component.md
+│       ├── create-issue.md
+│       ├── create-branch.md
+│       └── evaluate.md
+```
+
+### Source Files (in repo before setup, deleted after)
+
+```
+setup/
+├── workflows/
+│   ├── registry.ts                    # Command + feature section definitions
+│   ├── generate-claude-md.ts          # Assembles CLAUDE.md
+│   ├── generate-settings.ts           # Builds .claude/settings.json
+│   ├── generate-commands.ts           # Renders selected command files
+│   └── templates/
+│       ├── commands/
+│       │   ├── add-feature.md
+│       │   ├── new-screen.md
+│       │   ├── add-provider.md
+│       │   ├── run-checks.md
+│       │   ├── new-component.md
+│       │   ├── create-issue.md
+│       │   ├── create-branch.md
+│       │   └── evaluate.md
+│       └── sections/
+│           ├── header.md
+│           ├── conventions.md
+│           └── feature-guide.md
+```
+
+---
+
+## 3. Registry
+
+Central data structure used by all generators. Both setup and `/evaluate` use the same rules.
+
+### Command Definitions
+
+```typescript
+interface CommandDefinition {
+  id: string;
+  name: string;                    // Display name in wizard
+  description: string;             // Hint text
+  templateFile: string;            // Path to .md template
+  requiredFeatures?: string[];     // Only include if these features exist
+}
+```
+
+Commands:
+
+| ID | Name | Required Features |
+|----|------|------------------|
+| `add-feature` | /add-feature | — |
+| `new-screen` | /new-screen | — |
+| `add-provider` | /add-provider | Any feature with providers |
+| `run-checks` | /run-checks | — |
+| `new-component` | /new-component | — |
+| `create-issue` | /create-issue | — |
+| `create-branch` | /create-branch | — |
+| `evaluate` | /evaluate | — |
+
+### Feature Section Definitions
+
+```typescript
+interface FeatureSectionDefinition {
+  featureKey: string;
+  title: string;
+  files: string[];                 // Key files to reference
+  patterns: string[];              // Development guidance
+}
+```
+
+Each enabled feature gets a section in CLAUDE.md with:
+- Key file paths (service interface, provider, hooks)
+- How to extend it (add provider, modify behavior)
+- Testing guidance
+
+---
+
+## 4. CLAUDE.md Content
+
+### Manual Mode (minimal)
+
+```markdown
+# {appName}
+
+## Tech Stack
+(only selected tech — dynamically generated)
+
+## Project Structure
+(generated from actual src/ directory)
+
+## Commands
+(pnpm scripts from package.json)
+```
+
+### Agentic Mode (full)
+
+Adds on top of minimal:
+
+```markdown
+## Path Aliases
+- @/* → src/*
+- @assets/* → assets/*
+
+## Code Style
+- TypeScript strict mode — no any types
+- NativeWind className for styling (not StyleSheet.create)
+- kebab-case for file names
+- PascalCase for component names
+- Path aliases for imports — never relative paths
+- Functional components with hooks only
+- Named exports for components
+
+## Component Patterns
+- Reusable: src/components/
+- Base UI: src/components/ui/
+- Screen-specific: _components/ subfolder
+- Named exports only
+
+## Routing
+- Routes in src/app/ (expo-router conventions)
+- Route groups (groupName) for layout organization
+- Shared layouts: _layout.tsx files
+
+## Git Workflow
+- Branch naming: ft/<feature>, fix/<bug>, refactor/<description>
+- Conventional commits: feat:, fix:, refactor:, docs:, chore:
+- Always feature branches — never commit directly to main
+- Run pnpm lint before committing
+
+## Feature Architecture
+Each feature follows:
+  src/features/<name>/
+  ├── <name>-provider.tsx
+  ├── create-<name>-service.ts
+  ├── no-op-<name>.ts
+  ├── hooks/
+  ├── providers/
+  └── __tests__/
+
+## Feature Guide
+
+### Authentication
+- Service interface: src/services/auth.interface.ts
+- Provider: {provider} at src/features/auth/providers/{provider}.ts
+- Auth state: managed in AuthProvider via React Context
+- To add a new provider: implement AuthService, add to create-auth-service.ts
+
+### Theme System
+- Tokens: src/config/theme.config.ts
+- Runtime: useTheme() hook
+- Tailwind: auto-generated from tokens
+- To customize: edit theme.config.ts only
+
+{... one section per selected feature}
+```
+
+---
+
+## 5. Slash Commands
+
+### /add-feature
+
+Scaffold a new feature module. Asks for feature name, whether it needs providers, whether it needs a provider chain entry. Creates the full directory structure with provider, hooks, tests, barrel export, service interface, and types. Follows TDD. Runs /evaluate after.
+
+### /new-screen
+
+Create a new route/screen. Asks for screen name, route group, whether it needs a layout. Creates the file following existing patterns with ThemedView, ThemedText, NativeWind.
+
+### /add-provider
+
+Add a new provider to an existing feature. Asks which feature and provider name. Reads the service interface, creates the provider implementation, adds to factory, updates config type, writes tests, runs /evaluate.
+
+### /run-checks
+
+Runs `pnpm lint`, `pnpm typecheck`, `pnpm test --no-coverage` in sequence. Reports pass/fail for each. Investigates and suggests fixes on failure.
+
+### /new-component
+
+Create a reusable component. Asks for name and location (ui/ or components/). Uses NativeWind, useTheme()/useThemeColors(), named export, TypeScript props interface.
+
+### /create-issue
+
+Create a GitHub issue. Asks for title, description, labels. Runs `gh issue create`. Falls back to formatted output if gh not installed.
+
+### /create-branch
+
+Create a branch following naming convention. Asks for type and description. Maps to ft/, fix/, refactor/ prefix. Checks out main, pulls, creates branch.
+
+### /evaluate
+
+Self-contained codebase scanner and workflow file regenerator. Scans:
+- `src/features/` — which features exist
+- `src/features/*/providers/` — which providers per feature
+- `src/config/basekit.config.ts` — enabled features and providers
+- `src/components/` — available components
+- `src/hooks/` — available hooks
+- `src/app/` — route structure
+- `package.json` — dependencies and scripts
+- `.claude/commands/` — which commands exist
+
+Then regenerates:
+- CLAUDE.md with accurate content
+- .claude/commands/ — add/remove based on feature existence
+
+Commits the changes.
+
+---
+
+## 6. /evaluate — Self-Updating Mechanism
+
+### Two Entry Points, Same Rules
+
+- **During setup:** TypeScript generators in `setup/workflows/` produce initial files
+- **After setup:** `/evaluate` command (a self-contained markdown prompt) regenerates them by scanning the codebase
+
+The `setup/` directory is deleted after setup. The `/evaluate` command embeds all generation rules in its prompt — no runtime dependencies on setup code.
+
+### Detection Table
+
+| Change | Action |
+|--------|--------|
+| New feature directory | Add feature guide section to CLAUDE.md |
+| Feature directory removed | Remove section from CLAUDE.md |
+| New provider file | Update feature guide with provider |
+| New component | Update components list |
+| New hook | Update hooks list |
+| New route | Update route structure |
+| Dependency added/removed | Update tech stack |
+| No provider-based features remain | Remove /add-provider command |
+
+---
+
+## 7. .claude/settings.json
+
+Pre-configured permissions so common commands don't prompt:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm test*)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm start*)",
+      "Bash(git *)"
+    ]
+  }
+}
+```
+
+---
+
+## 8. Quick Mode Defaults
+
+`pnpm run setup --quick` defaults:
+- workflow: `manual`
+- agents: `[]`
+- commands: `[]`
+
+This keeps quick mode fast — no workflow file generation. Developers can add agentic workflows later by manually creating CLAUDE.md or running the evaluate pattern.

--- a/docs/superpowers/specs/2026-03-26-agentic-workflows-design.md
+++ b/docs/superpowers/specs/2026-03-26-agentic-workflows-design.md
@@ -324,11 +324,199 @@ Pre-configured permissions so common commands don't prompt:
 
 ---
 
-## 8. Quick Mode Defaults
+## 8. Integration with Setup Wizard
+
+### Step Sequence
+
+Workflow generation inserts into the existing setup flow at step 8.5 — after theme handling, before pnpm install:
+
+1. Update app.json
+2. Strip feature files
+3. Rewrite service factories
+4. Rewrite app-providers.tsx
+5. Update config
+6. Clean package.json
+7. Update .env.example
+8. Handle theme
+9. **Generate workflow files** (new step)
+10. pnpm install
+11. Self-destruct (removes `setup/` including `setup/workflows/`)
+12. Git commit
+
+This ordering ensures the generators can read the already-stripped codebase to produce accurate output, and the `setup/workflows/` source is still available.
+
+### YAML Config File (`--from`) Extension
+
+```yaml
+# basekit.scaffold.yaml
+app:
+  name: my-app
+  bundleId: com.acme.myapp
+  scheme: myapp
+theme: corporate
+backend: supabase
+features:
+  - auth
+  - analytics
+  - security
+workflow: agentic
+agents:
+  - claude-code
+commands:
+  - add-feature
+  - new-screen
+  - add-provider
+  - run-checks
+  - evaluate
+```
+
+If `workflow` is omitted, defaults to `manual`. If `agents` or `commands` are omitted when `workflow: agentic`, uses all available.
+
+### Quick Mode Defaults
 
 `pnpm run setup --quick` defaults:
 - workflow: `manual`
 - agents: `[]`
 - commands: `[]`
 
-This keeps quick mode fast — no workflow file generation. Developers can add agentic workflows later by manually creating CLAUDE.md or running the evaluate pattern.
+### `getQuickDefaults()` Update
+
+```typescript
+export function getQuickDefaults(): SetupAnswers {
+  return {
+    // ... existing fields
+    workflow: 'manual',
+    agents: [],
+    commands: [],
+  };
+}
+```
+
+---
+
+## 9. Settings Permissions
+
+Generated `.claude/settings.json` uses granular permissions matching Claude Code conventions:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm start)",
+      "Bash(pnpm start:*)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git push*)",
+      "Bash(git pull*)",
+      "Bash(git fetch*)",
+      "Bash(gh issue*)",
+      "Bash(gh pr*)"
+    ]
+  }
+}
+```
+
+Note: This is the settings for the **scaffolded project**, not for this repo. The Basekit repo itself has its own `.claude/settings.json` which is distinct.
+
+---
+
+## 10. Command Availability Logic
+
+### `add-provider` Conditional
+
+The `/add-provider` command requires at least one feature with swappable providers to be present. This cannot be expressed as a simple `requiredFeatures` string array.
+
+```typescript
+interface CommandDefinition {
+  id: string;
+  name: string;
+  description: string;
+  templateFile: string;
+  condition?: (selectedFeatures: Record<string, string>, manifest: Manifest) => boolean;
+}
+```
+
+For `add-provider`:
+```typescript
+{
+  id: 'add-provider',
+  condition: (selected, manifest) =>
+    Object.keys(selected).some((f) => {
+      const feature = manifest.features[f];
+      return feature && Object.keys(feature.providers).length > 0;
+    }),
+}
+```
+
+Commands without a `condition` are always available (if selected by the user).
+
+---
+
+## 11. Template Interpolation
+
+Templates use simple `{{variable}}` placeholders processed by string replacement. No template library needed — the generators do:
+
+```typescript
+function renderTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');
+}
+```
+
+Variables available to templates:
+- `{{appName}}` — from setup answers
+- `{{bundleId}}` — from setup answers
+- `{{scheme}}` — from setup answers
+- `{{features}}` — comma-separated list of enabled features
+- `{{provider:featureName}}` — selected provider for a feature
+
+Feature guide sections use a different approach — they are generated programmatically from the `FeatureSectionDefinition` registry, not from templates with conditionals.
+
+---
+
+## 12. `.gitignore` Handling
+
+The `.claude/` directory should be committed to the scaffolded project — it's part of the developer experience. It is NOT added to `.gitignore`.
+
+In manual mode, no `.claude/` directory is created, so nothing to manage.
+
+---
+
+## 13. Drift Prevention Between Setup Generators and /evaluate
+
+The `/evaluate` command is the **canonical source of truth** for workflow file structure. The TypeScript generators in `setup/workflows/` are written to follow the same rules defined in the evaluate command's template.
+
+To verify parity, the implementation should include an integration test that:
+1. Runs setup with agentic mode
+2. Runs `/evaluate` (simulated by calling the same scan + generate logic)
+3. Asserts the output matches what setup produced
+
+---
+
+## 14. Feature Section Registry (All Features)
+
+Complete registry entries for all features:
+
+| Feature | Key Files | Guidance |
+|---------|-----------|----------|
+| auth | auth-provider.tsx, create-auth-service.ts, services/auth.interface.ts | Add providers in providers/, implement AuthService interface |
+| analytics | analytics-provider.tsx, create-analytics-service.ts, services/analytics.interface.ts | Track events via useAnalytics(), add providers following amplify.ts pattern |
+| crash-reporting | crash-reporting-provider.tsx, services/crash-reporting.interface.ts | Capture errors via useCrashReporting(), Sentry provider at providers/sentry.ts |
+| notifications | notification-provider.tsx, services/notifications.interface.ts | Request permissions, send local notifications via useNotifications() |
+| offline-storage | storage-provider.tsx, create-storage-service.ts, services/storage.interface.ts | Key-value storage via useStorage(), MMKV or AsyncStorage providers |
+| i18n | i18n-provider.tsx, i18n.ts, locales/en.json | Add translations in locales/, use useAppTranslation() hook |
+| forms | hooks/use-app-form.ts, components/form-input.tsx, schemas/common.ts | Zod schemas in schemas/, form components in components/ |
+| security | security-provider.tsx, hooks/use-biometrics.ts, hooks/use-app-lock.ts, config/pinning.ts | Biometrics via useBiometrics(), secure storage via useSecureStorage(), SSL config in config/pinning.ts |
+| theme | theme-provider.tsx, hooks/use-theme.ts, utils/generate-tailwind.ts, config/theme.config.ts | Edit theme.config.ts to change tokens, useTheme() for runtime values, Tailwind classes auto-update |
+| onboarding | hooks/use-onboarding.ts, components/onboarding-screen.tsx | Completion persisted in Zustand store, check useOnboarding().shouldShow |
+| deep-linking | hooks/use-deep-link.ts, utils/build-deep-link.ts | Monitor incoming URLs via useDeepLink(), build links with buildDeepLink() |
+| ota-updates | hooks/use-ota-updates.ts | Check and apply updates via useOtaUpdates() |
+| splash-app-icon | hooks/use-splash-screen.ts | Control splash visibility via useSplashScreen() |

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -8,6 +8,9 @@ import { runInteractivePrompts, getQuickDefaults } from './prompts';
 import type { SetupAnswers } from './prompts';
 import { resolveFeaturesToStrip, collectDepsToRemove, collectEnvVarsToKeep } from './generator';
 import type { Manifest } from './generator';
+import { generateClaudeMd } from './workflows/generate-claude-md';
+import { generateSettings } from './workflows/generate-settings';
+import { getAvailableCommands } from './workflows/generate-commands';
 import { generateAppProviders } from './providers';
 import { removeFeatureFiles, cleanPackageJson, updateEnvExample, updateAppJson, rewriteServiceFactory } from './utils';
 
@@ -64,7 +67,7 @@ async function main() {
   if (isQuick) {
     answers = getQuickDefaults();
     p.intro(color.bgCyan(color.black(' Basekit — Quick Setup ')));
-    p.log.info(`Theme: minimal | Backend: none | Features: offline-storage, i18n, forms`);
+    p.log.info(`Theme: minimal | Backend: none | Features: offline-storage, i18n, forms | Workflow: manual`);
   } else if (fromFile) {
     const configContent = await fs.readFile(fromFile, 'utf-8');
     const config = YAML.parse(configContent);
@@ -75,6 +78,9 @@ async function main() {
       theme: config.theme ?? null,
       backend: config.backend ?? null,
       features: {} as Record<string, string>,
+      workflow: 'manual' as 'agentic' | 'manual',
+      agents: [],
+      commands: [],
     };
     for (const feat of config.features ?? []) {
       const feature = manifest.features[feat];
@@ -94,6 +100,9 @@ async function main() {
     if (answers.theme) {
       answers.features['theme'] = answers.theme;
     }
+    answers.workflow = (config.workflow as 'agentic' | 'manual') ?? 'manual';
+    answers.agents = (config.agents as string[]) ?? [];
+    answers.commands = (config.commands as string[]) ?? [];
     p.intro(color.bgCyan(color.black(` Basekit — Config: ${fromFile} `)));
   } else {
     answers = await runInteractivePrompts(manifest);
@@ -132,6 +141,9 @@ async function main() {
         `Routes to remove: ${stripResult.routesToRemove.join(', ') || 'none'}`,
         `Dependencies to remove: ${depsToRemove.length}`,
         `Env vars to keep: ${envVarsToKeep.join(', ')}`,
+        `Workflow: ${answers.workflow}`,
+        `Agents: ${answers.agents.join(', ') || 'none'}`,
+        `Commands: ${answers.commands.join(', ') || 'none'}`,
       ].join('\n'),
       'Dry Run Summary',
     );
@@ -253,6 +265,39 @@ async function main() {
     }
     s.stop(color.green(`Applied theme preset: ${answers.theme}`));
   }
+
+  // Generate workflow files
+  s.start('Generating workflow files');
+  const claudeMd = generateClaudeMd({
+    appName: answers.appName,
+    bundleId: answers.bundleId,
+    scheme: answers.scheme,
+    features: answers.features,
+    workflow: answers.workflow,
+  });
+  await fs.writeFile(path.join(PROJECT_ROOT, 'CLAUDE.md'), claudeMd);
+
+  if (answers.workflow === 'agentic' && answers.agents.includes('claude-code')) {
+    await fs.ensureDir(path.join(PROJECT_ROOT, '.claude'));
+    await fs.writeJson(
+      path.join(PROJECT_ROOT, '.claude', 'settings.json'),
+      generateSettings(),
+      { spaces: 2 },
+    );
+
+    const availableCommands = getAvailableCommands(answers.commands, answers.features, manifest);
+    const commandsDir = path.join(PROJECT_ROOT, '.claude', 'commands');
+    await fs.ensureDir(commandsDir);
+
+    for (const cmd of availableCommands) {
+      const templatePath = path.join(__dirname, 'workflows', 'templates', cmd.templateFile);
+      if (await fs.pathExists(templatePath)) {
+        const content = await fs.readFile(templatePath, 'utf-8');
+        await fs.writeFile(path.join(commandsDir, `${cmd.id}.md`), content);
+      }
+    }
+  }
+  s.stop(color.green('Generated workflow files'));
 
   // Step 8: pnpm install
   s.start('Installing dependencies');

--- a/setup/prompts.ts
+++ b/setup/prompts.ts
@@ -9,6 +9,9 @@ export interface SetupAnswers {
   theme: string | null;
   backend: string | null;
   features: Record<string, string>;
+  workflow: 'agentic' | 'manual';
+  agents: string[];
+  commands: string[];
 }
 
 export function validateDependencies(
@@ -168,6 +171,62 @@ export async function runInteractivePrompts(manifest: Manifest): Promise<SetupAn
     }
   }
 
+  // Workflow mode
+  const workflow = await p.select({
+    message: 'Development workflow',
+    options: [
+      { value: 'agentic', label: 'Agentic', hint: 'Generate AI agent workflow files' },
+      { value: 'manual', label: 'Manual', hint: 'Minimal project context only' },
+    ],
+  });
+
+  if (p.isCancel(workflow)) {
+    p.cancel('Setup cancelled.');
+    process.exit(0);
+  }
+
+  let agents: string[] = [];
+  let selectedCommands: string[] = [];
+
+  if (workflow === 'agentic') {
+    const agentChoice = await p.multiselect({
+      message: 'Select agents',
+      options: [
+        { value: 'claude-code', label: 'Claude Code', hint: 'CLAUDE.md + .claude/ commands' },
+      ],
+      required: true,
+    });
+
+    if (p.isCancel(agentChoice)) {
+      p.cancel('Setup cancelled.');
+      process.exit(0);
+    }
+    agents = agentChoice as string[];
+
+    if (agents.includes('claude-code')) {
+      const { commands: registryCommands } = await import('./workflows/registry');
+      const filteredCommands = registryCommands.filter(
+        (cmd) => !cmd.condition || cmd.condition(features, manifest),
+      );
+
+      const commandChoice = await p.multiselect({
+        message: 'Select workflow commands',
+        options: filteredCommands.map((cmd) => ({
+          value: cmd.id,
+          label: cmd.name,
+          hint: cmd.description,
+        })),
+        required: false,
+      });
+
+      if (p.isCancel(commandChoice)) {
+        p.cancel('Setup cancelled.');
+        process.exit(0);
+      }
+      selectedCommands = commandChoice as string[];
+    }
+  }
+
   return {
     appName: appInfo.appName,
     bundleId: appInfo.bundleId,
@@ -175,6 +234,9 @@ export async function runInteractivePrompts(manifest: Manifest): Promise<SetupAn
     theme: theme === 'none' ? null : (theme as string),
     backend: backend === 'none' ? null : (backend as string),
     features,
+    workflow: workflow as 'agentic' | 'manual',
+    agents,
+    commands: selectedCommands,
   };
 }
 
@@ -191,5 +253,8 @@ export function getQuickDefaults(): SetupAnswers {
       forms: '',
       theme: 'minimal',
     },
+    workflow: 'manual' as const,
+    agents: [],
+    commands: [],
   };
 }

--- a/setup/workflows/__tests__/generate-claude-md.test.ts
+++ b/setup/workflows/__tests__/generate-claude-md.test.ts
@@ -1,0 +1,61 @@
+import { generateClaudeMd } from '../generate-claude-md';
+
+describe('generateClaudeMd', () => {
+  const baseAnswers = {
+    appName: 'test-app',
+    bundleId: 'com.test.app',
+    scheme: 'testapp',
+    features: { auth: 'amplify', i18n: '', theme: 'minimal' } as Record<string, string>,
+  };
+
+  it('should generate minimal CLAUDE.md for manual mode', () => {
+    const result = generateClaudeMd({ ...baseAnswers, workflow: 'manual' as const });
+
+    expect(result).toContain('# test-app');
+    expect(result).toContain('## Tech Stack');
+    expect(result).toContain('## Commands');
+    expect(result).not.toContain('## Code Style');
+    expect(result).not.toContain('## Feature Guide');
+  });
+
+  it('should generate full CLAUDE.md for agentic mode', () => {
+    const result = generateClaudeMd({ ...baseAnswers, workflow: 'agentic' as const });
+
+    expect(result).toContain('# test-app');
+    expect(result).toContain('## Code Style');
+    expect(result).toContain('## Feature Architecture');
+    expect(result).toContain('## Feature Guide');
+    expect(result).toContain('### Authentication');
+    expect(result).toContain('### Internationalization');
+    expect(result).toContain('### Theme System');
+  });
+
+  it('should only include guides for selected features', () => {
+    const result = generateClaudeMd({
+      appName: 'test-app',
+      bundleId: 'com.test.app',
+      scheme: 'testapp',
+      features: { auth: 'amplify' },
+      workflow: 'agentic' as const,
+    });
+
+    expect(result).toContain('### Authentication');
+    expect(result).not.toContain('### Theme System');
+    expect(result).not.toContain('### Internationalization');
+  });
+
+  it('should include provider info in feature guides', () => {
+    const result = generateClaudeMd({ ...baseAnswers, workflow: 'agentic' as const });
+
+    expect(result).toContain('amplify');
+    expect(result).toContain('src/services/auth.interface.ts');
+  });
+
+  it('should include tech stack entries for selected features', () => {
+    const result = generateClaudeMd({ ...baseAnswers, workflow: 'manual' as const });
+
+    expect(result).toContain('i18next');
+    expect(result).toContain('Theming');
+    expect(result).not.toContain('Forms');
+  });
+});

--- a/setup/workflows/__tests__/generate-commands.test.ts
+++ b/setup/workflows/__tests__/generate-commands.test.ts
@@ -1,0 +1,38 @@
+import { getAvailableCommands } from '../generate-commands';
+import { commands } from '../registry';
+
+describe('getAvailableCommands', () => {
+  const mockManifest = {
+    features: {
+      auth: { providers: { amplify: { files: [], dependencies: {}, envVars: { required: [], optional: [] } } }, sharedFiles: [], sharedDependencies: {}, requires: [], enhancedBy: [], providerChain: null, routes: [], displayName: 'Auth', description: '', category: 'auth' },
+      i18n: { providers: {}, sharedFiles: [], sharedDependencies: {}, requires: [], enhancedBy: [], providerChain: null, routes: [], displayName: 'i18n', description: '', category: 'i18n' },
+    },
+    categories: {},
+  };
+
+  it('should include add-provider when features have providers', () => {
+    const selected = { auth: 'amplify', i18n: '' };
+    const selectedCommands = commands.map((c) => c.id);
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result.map((c) => c.id)).toContain('add-provider');
+    expect(result.map((c) => c.id)).toContain('add-feature');
+  });
+
+  it('should exclude add-provider when no features have providers', () => {
+    const selected = { i18n: '' };
+    const selectedCommands = commands.map((c) => c.id);
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result.map((c) => c.id)).not.toContain('add-provider');
+  });
+
+  it('should only return user-selected commands', () => {
+    const selected = { auth: 'amplify' };
+    const selectedCommands = ['run-checks', 'evaluate'];
+    const result = getAvailableCommands(selectedCommands, selected, mockManifest as never);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['run-checks', 'evaluate']);
+  });
+});

--- a/setup/workflows/generate-claude-md.ts
+++ b/setup/workflows/generate-claude-md.ts
@@ -1,0 +1,174 @@
+import { featureSections } from './registry';
+
+interface GenerateOptions {
+  appName: string;
+  bundleId: string;
+  scheme: string;
+  features: Record<string, string>;
+  workflow: 'agentic' | 'manual';
+}
+
+export function generateClaudeMd(options: GenerateOptions): string {
+  const { appName, features, workflow } = options;
+  const sections: string[] = [];
+
+  sections.push(`# ${appName}\n`);
+  sections.push(generateTechStack(features));
+  sections.push(generateProjectStructure(features));
+  sections.push(generateCommands());
+
+  if (workflow === 'agentic') {
+    sections.push(generatePathAliases());
+    sections.push(generateCodeStyle());
+    sections.push(generateComponentPatterns());
+    sections.push(generateRouting());
+    sections.push(generateGitWorkflow());
+    sections.push(generateFeatureArchitecture());
+    sections.push(generateFeatureGuide(features));
+  }
+
+  return sections.join('\n');
+}
+
+function generateTechStack(features: Record<string, string>): string {
+  const lines = [
+    '## Tech Stack',
+    '- **Runtime**: Expo SDK 54 with React Native 0.81',
+    '- **Language**: TypeScript (strict mode)',
+    '- **Navigation**: expo-router (file-based routing)',
+    '- **Styling**: NativeWind v4 + TailwindCSS 3.4',
+    '- **Package Manager**: pnpm',
+  ];
+
+  if ('theme' in features) lines.push('- **Theming**: Design tokens via theme.config.ts');
+  if ('auth' in features) lines.push(`- **Auth**: ${features.auth || 'configured'}`);
+  if ('analytics' in features) lines.push(`- **Analytics**: ${features.analytics || 'configured'}`);
+  if ('crash-reporting' in features) lines.push(`- **Crash Reporting**: ${features['crash-reporting'] || 'configured'}`);
+  if ('i18n' in features) lines.push('- **i18n**: i18next + react-i18next');
+  if ('forms' in features) lines.push('- **Forms**: React Hook Form + Zod');
+  if ('security' in features) lines.push('- **Security**: expo-local-authentication + expo-secure-store');
+  if ('offline-storage' in features) lines.push(`- **Storage**: ${features['offline-storage'] || 'configured'}`);
+
+  return lines.join('\n') + '\n';
+}
+
+function generateProjectStructure(features: Record<string, string>): string {
+  const featureKeys = Object.keys(features).filter((f) => f !== 'theme');
+  const featureDirs = featureKeys.map((f) => `│   ├── ${f}/`).join('\n');
+  const themeDir = 'theme' in features ? '\n│   ├── theme/' : '';
+
+  return `## Project Structure
+\`\`\`
+src/
+├── app/              # Expo Router file-based routes
+├── components/       # Reusable components
+│   └── ui/           # Base UI components
+├── config/           # basekit.config.ts${themeDir ? ', theme.config.ts' : ''}
+├── features/         # Feature modules
+${featureDirs}${themeDir}
+├── hooks/            # Shared React hooks
+├── lib/              # Library wrappers (api, providers)
+├── services/         # Service interfaces
+├── store/            # Zustand stores
+└── types/            # Shared TypeScript types
+\`\`\`
+`;
+}
+
+function generateCommands(): string {
+  return `## Commands
+- \`pnpm start\` — Start Expo dev server
+- \`pnpm android\` — Start on Android
+- \`pnpm ios\` — Start on iOS
+- \`pnpm web\` — Start on web
+- \`pnpm lint\` — Run ESLint
+- \`pnpm typecheck\` — TypeScript type checking
+- \`pnpm test\` — Run unit tests
+- \`pnpm test:coverage\` — Test coverage report
+`;
+}
+
+function generatePathAliases(): string {
+  return `## Path Aliases
+- \`@/*\` → \`src/*\`
+- \`@assets/*\` → \`assets/*\`
+`;
+}
+
+function generateCodeStyle(): string {
+  return `## Code Style
+- Use TypeScript with strict mode — no \`any\` types
+- Use NativeWind className for styling (not StyleSheet.create)
+- Use kebab-case for file names (e.g., \`my-component.tsx\`)
+- Use PascalCase for component names
+- Use path aliases (\`@/\`, \`@assets/\`) for imports — never relative paths like \`../../\`
+- Functional components with hooks only — no class components
+- Export components as named exports (not default)
+`;
+}
+
+function generateComponentPatterns(): string {
+  return `## Component Patterns
+- Place reusable components in \`src/components/\`
+- Place base/primitive UI components in \`src/components/ui/\`
+- Place screen-specific components alongside their route files or in a \`_components/\` subfolder
+- Export components as named exports
+`;
+}
+
+function generateRouting(): string {
+  return `## Routing
+- All routes live in \`src/app/\` following expo-router conventions
+- Use route groups \`(groupName)\` for layout organization
+- Shared layouts use \`_layout.tsx\` files
+`;
+}
+
+function generateGitWorkflow(): string {
+  return `## Git Workflow
+- Branch naming: \`ft/<feature-name>\`, \`fix/<bug-name>\`, \`refactor/<description>\`
+- Commit messages: conventional commits (feat:, fix:, refactor:, docs:, chore:)
+- Always create feature branches — never commit directly to \`main\`
+- Run \`pnpm lint\` before committing
+`;
+}
+
+function generateFeatureArchitecture(): string {
+  return `## Feature Architecture
+Each feature follows this pattern:
+\`\`\`
+src/features/<name>/
+├── <name>-provider.tsx      # React context provider (with feature toggle)
+├── create-<name>-service.ts # Factory with dynamic imports (if swappable providers)
+├── no-op-<name>.ts          # Fallback when feature disabled
+├── hooks/                   # Public hooks consumed by the app
+├── providers/               # Swappable provider implementations
+└── __tests__/               # Unit tests
+\`\`\`
+`;
+}
+
+function generateFeatureGuide(features: Record<string, string>): string {
+  const sections = featureSections
+    .filter((s) => s.featureKey in features)
+    .map((s) => {
+      const provider = features[s.featureKey];
+      const lines = [`### ${s.title}`, ''];
+      lines.push('**Key files:**');
+      for (const f of s.files) {
+        lines.push(`- \`${f}\``);
+      }
+      lines.push('');
+      if (provider) {
+        lines.push(`**Provider:** ${provider}`);
+        lines.push('');
+      }
+      lines.push('**Patterns:**');
+      for (const p of s.patterns) {
+        lines.push(`- ${p}`);
+      }
+      return lines.join('\n');
+    });
+
+  return `## Feature Guide\n\n${sections.join('\n\n')}\n`;
+}

--- a/setup/workflows/generate-commands.ts
+++ b/setup/workflows/generate-commands.ts
@@ -1,0 +1,15 @@
+import { commands } from './registry';
+import type { CommandDefinition } from './registry';
+import type { Manifest } from '../generator';
+
+export function getAvailableCommands(
+  selectedCommandIds: string[],
+  selectedFeatures: Record<string, string>,
+  manifest: Manifest,
+): CommandDefinition[] {
+  return commands.filter((cmd) => {
+    if (!selectedCommandIds.includes(cmd.id)) return false;
+    if (cmd.condition && !cmd.condition(selectedFeatures, manifest)) return false;
+    return true;
+  });
+}

--- a/setup/workflows/generate-settings.ts
+++ b/setup/workflows/generate-settings.ts
@@ -1,0 +1,26 @@
+export function generateSettings(): object {
+  return {
+    permissions: {
+      allow: [
+        'Bash(pnpm lint)',
+        'Bash(pnpm test)',
+        'Bash(pnpm test:*)',
+        'Bash(pnpm typecheck)',
+        'Bash(pnpm start)',
+        'Bash(pnpm start:*)',
+        'Bash(git status*)',
+        'Bash(git log*)',
+        'Bash(git diff*)',
+        'Bash(git branch*)',
+        'Bash(git checkout*)',
+        'Bash(git add*)',
+        'Bash(git commit*)',
+        'Bash(git push*)',
+        'Bash(git pull*)',
+        'Bash(git fetch*)',
+        'Bash(gh issue*)',
+        'Bash(gh pr*)',
+      ],
+    },
+  };
+}

--- a/setup/workflows/registry.ts
+++ b/setup/workflows/registry.ts
@@ -1,0 +1,192 @@
+import type { Manifest } from '../generator';
+
+export interface CommandDefinition {
+  id: string;
+  name: string;
+  description: string;
+  templateFile: string;
+  condition?: (selectedFeatures: Record<string, string>, manifest: Manifest) => boolean;
+}
+
+export interface FeatureSectionDefinition {
+  featureKey: string;
+  title: string;
+  files: string[];
+  patterns: string[];
+}
+
+export const commands: CommandDefinition[] = [
+  {
+    id: 'add-feature',
+    name: '/add-feature',
+    description: 'Scaffold a new feature module',
+    templateFile: 'commands/add-feature.md',
+  },
+  {
+    id: 'new-screen',
+    name: '/new-screen',
+    description: 'Create a new route/screen',
+    templateFile: 'commands/new-screen.md',
+  },
+  {
+    id: 'add-provider',
+    name: '/add-provider',
+    description: 'Add provider to existing feature',
+    templateFile: 'commands/add-provider.md',
+    condition: (selected, manifest) =>
+      Object.keys(selected).some((f) => {
+        const feature = manifest.features[f];
+        return feature && Object.keys(feature.providers).length > 0;
+      }),
+  },
+  {
+    id: 'run-checks',
+    name: '/run-checks',
+    description: 'Lint + typecheck + test',
+    templateFile: 'commands/run-checks.md',
+  },
+  {
+    id: 'new-component',
+    name: '/new-component',
+    description: 'Scaffold a component',
+    templateFile: 'commands/new-component.md',
+  },
+  {
+    id: 'create-issue',
+    name: '/create-issue',
+    description: 'Create a GitHub issue',
+    templateFile: 'commands/create-issue.md',
+  },
+  {
+    id: 'create-branch',
+    name: '/create-branch',
+    description: 'Create a feature branch',
+    templateFile: 'commands/create-branch.md',
+  },
+  {
+    id: 'evaluate',
+    name: '/evaluate',
+    description: 'Scan codebase and update workflow files',
+    templateFile: 'commands/evaluate.md',
+  },
+];
+
+export const featureSections: FeatureSectionDefinition[] = [
+  {
+    featureKey: 'auth',
+    title: 'Authentication',
+    files: ['src/services/auth.interface.ts', 'src/features/auth/auth-provider.tsx', 'src/features/auth/create-auth-service.ts'],
+    patterns: [
+      'Service interface at src/services/auth.interface.ts — all providers implement this',
+      'Add new providers in src/features/auth/providers/ following existing pattern',
+      'Auth state managed in AuthProvider via React Context',
+      'Token getter wired into API client automatically',
+    ],
+  },
+  {
+    featureKey: 'analytics',
+    title: 'Analytics',
+    files: ['src/services/analytics.interface.ts', 'src/features/analytics/analytics-provider.tsx', 'src/features/analytics/create-analytics-service.ts'],
+    patterns: [
+      'Track events via useAnalytics() hook',
+      'Add providers following amplify.ts pattern in providers/',
+    ],
+  },
+  {
+    featureKey: 'crash-reporting',
+    title: 'Crash Reporting',
+    files: ['src/services/crash-reporting.interface.ts', 'src/features/crash-reporting/crash-reporting-provider.tsx'],
+    patterns: [
+      'Capture errors via useCrashReporting() hook',
+      'Sentry provider at providers/sentry.ts',
+    ],
+  },
+  {
+    featureKey: 'notifications',
+    title: 'Push Notifications',
+    files: ['src/services/notifications.interface.ts', 'src/features/notifications/notification-provider.tsx'],
+    patterns: [
+      'Request permissions, send local notifications via useNotifications()',
+      'Add providers following amplify.ts pattern',
+    ],
+  },
+  {
+    featureKey: 'offline-storage',
+    title: 'Offline Storage',
+    files: ['src/services/storage.interface.ts', 'src/features/offline-storage/storage-provider.tsx', 'src/features/offline-storage/create-storage-service.ts'],
+    patterns: [
+      'Key-value storage via useStorage() hook',
+      'MMKV or AsyncStorage providers available',
+    ],
+  },
+  {
+    featureKey: 'i18n',
+    title: 'Internationalization',
+    files: ['src/features/i18n/i18n-provider.tsx', 'src/features/i18n/i18n.ts', 'src/features/i18n/locales/en.json'],
+    patterns: [
+      'Add translations in src/features/i18n/locales/',
+      'Use useAppTranslation() hook in components',
+    ],
+  },
+  {
+    featureKey: 'forms',
+    title: 'Forms & Validation',
+    files: ['src/features/forms/hooks/use-app-form.ts', 'src/features/forms/components/form-input.tsx', 'src/features/forms/schemas/common.ts'],
+    patterns: [
+      'Zod schemas in schemas/, form components in components/',
+      'Use useAppForm(schema) hook for form state',
+    ],
+  },
+  {
+    featureKey: 'security',
+    title: 'Security',
+    files: ['src/features/security/security-provider.tsx', 'src/features/security/hooks/use-biometrics.ts', 'src/features/security/hooks/use-app-lock.ts', 'src/features/security/config/pinning.ts'],
+    patterns: [
+      'Biometrics via useBiometrics() hook',
+      'Secure storage via useSecureStorage() hook',
+      'App lock via useAppLock() hook',
+      'SSL pinning config in config/pinning.ts',
+    ],
+  },
+  {
+    featureKey: 'theme',
+    title: 'Theme System',
+    files: ['src/config/theme.config.ts', 'src/features/theme/hooks/use-theme.ts', 'src/features/theme/utils/generate-tailwind.ts'],
+    patterns: [
+      'Edit theme.config.ts to change design tokens — no component changes needed',
+      'useTheme() hook for runtime values (colors, spacing, shadows)',
+      'Tailwind classes auto-generated from tokens (bg-primary-500, etc.)',
+      'useThemeColors() is a safe wrapper that falls back when theme is disabled',
+    ],
+  },
+  {
+    featureKey: 'onboarding',
+    title: 'Onboarding',
+    files: ['src/features/onboarding/hooks/use-onboarding.ts', 'src/features/onboarding/components/onboarding-screen.tsx'],
+    patterns: [
+      'Completion persisted in Zustand store',
+      'Check useOnboarding().shouldShow to decide whether to show onboarding',
+    ],
+  },
+  {
+    featureKey: 'deep-linking',
+    title: 'Deep Linking',
+    files: ['src/features/deep-linking/hooks/use-deep-link.ts', 'src/features/deep-linking/utils/build-deep-link.ts'],
+    patterns: [
+      'Monitor incoming URLs via useDeepLink() hook',
+      'Build links with buildDeepLink() utility',
+    ],
+  },
+  {
+    featureKey: 'ota-updates',
+    title: 'OTA Updates',
+    files: ['src/features/ota-updates/hooks/use-ota-updates.ts'],
+    patterns: ['Check and apply updates via useOtaUpdates() hook'],
+  },
+  {
+    featureKey: 'splash-app-icon',
+    title: 'Splash Screen & App Icon',
+    files: ['src/features/splash-app-icon/hooks/use-splash-screen.ts'],
+    patterns: ['Control splash visibility via useSplashScreen() hook'],
+  },
+];

--- a/setup/workflows/templates/commands/add-feature.md
+++ b/setup/workflows/templates/commands/add-feature.md
@@ -1,0 +1,28 @@
+Create a new feature module following the Basekit pattern.
+
+Ask the user for:
+1. Feature name (kebab-case)
+2. Does it need swappable providers? (Y/n)
+3. Does it need a provider chain entry in app-providers.tsx? (Y/n)
+
+Then scaffold these files:
+- `src/features/{name}/{name}-provider.tsx` — React context provider
+- `src/features/{name}/hooks/use-{name}.ts` — Public hook
+- `src/features/{name}/__tests__/` — Test directory
+- `src/features/{name}/index.ts` — Barrel export
+
+If providers needed, also create:
+- `src/features/{name}/create-{name}-service.ts` — Factory with dynamic imports
+- `src/features/{name}/no-op-{name}.ts` — No-op fallback
+- `src/features/{name}/providers/` — Provider directory
+- `src/services/{name}.interface.ts` — Service contract
+- `src/types/{name}.types.ts` — Types
+
+If provider chain needed:
+- Add the provider to `src/lib/providers/app-providers.tsx`
+- Add feature config to `src/config/basekit.config.ts`
+
+Follow TDD — write tests first, then implementation.
+Use path aliases (`@/`) for all imports.
+Use NativeWind className for any UI.
+After scaffolding, run `/evaluate` to update CLAUDE.md.

--- a/setup/workflows/templates/commands/add-provider.md
+++ b/setup/workflows/templates/commands/add-provider.md
@@ -1,0 +1,14 @@
+Add a new provider implementation to an existing feature.
+
+Ask the user for:
+1. Which feature? (list features in `src/features/` that have a `providers/` directory)
+2. Provider name (kebab-case)
+
+Steps:
+1. Read the service interface at `src/services/{feature}.interface.ts`
+2. Create `src/features/{feature}/providers/{provider}.ts` implementing the full interface
+3. Add the provider to the dynamic import map in `create-{feature}-service.ts`
+4. Add the provider name to the union type in `src/config/basekit.config.ts`
+5. Write unit tests for the new provider in `src/features/{feature}/__tests__/`
+6. Run `pnpm lint && pnpm typecheck && pnpm test`
+7. Run `/evaluate` to update CLAUDE.md with the new provider

--- a/setup/workflows/templates/commands/create-branch.md
+++ b/setup/workflows/templates/commands/create-branch.md
@@ -1,0 +1,17 @@
+Create a feature branch following the project's naming convention.
+
+Ask the user for:
+1. Type: feature, fix, or refactor
+2. Short description (will be converted to kebab-case)
+
+Map type to prefix:
+- feature → `ft/`
+- fix → `fix/`
+- refactor → `refactor/`
+
+Run:
+```bash
+git checkout main
+git pull origin main
+git checkout -b {prefix}{description-in-kebab-case}
+```

--- a/setup/workflows/templates/commands/create-issue.md
+++ b/setup/workflows/templates/commands/create-issue.md
@@ -1,0 +1,13 @@
+Create a GitHub issue for tracking work.
+
+Ask the user for:
+1. Issue title
+2. Description
+3. Labels: bug, feature, enhancement, docs (can select multiple)
+
+Run:
+```bash
+gh issue create --title "{title}" --body "{description}" --label "{labels}"
+```
+
+If the `gh` CLI is not installed, format the issue as markdown output the user can copy-paste into GitHub's web UI.

--- a/setup/workflows/templates/commands/evaluate.md
+++ b/setup/workflows/templates/commands/evaluate.md
@@ -1,0 +1,45 @@
+Scan the codebase and regenerate workflow files to match the current project state.
+
+## What to scan
+
+1. **Features:** List all directories in `src/features/`
+2. **Providers:** For each feature, list files in `src/features/{name}/providers/`
+3. **Config:** Read `src/config/basekit.config.ts` — extract enabled features and providers
+4. **Components:** List all `.tsx` files in `src/components/` and `src/components/ui/`
+5. **Hooks:** List all `.ts` files in `src/hooks/`
+6. **Routes:** List all route files in `src/app/` (recursively, including route groups)
+7. **Dependencies:** Read `package.json` — extract dependency names
+8. **Scripts:** Read `package.json` scripts section
+9. **Commands:** List existing `.md` files in `.claude/commands/`
+
+## How to regenerate CLAUDE.md
+
+Rewrite CLAUDE.md with these sections in order:
+
+1. **Header:** `# {app name from basekit.config.ts}`
+2. **Tech Stack:** List runtime, language, navigation, styling, and only technologies for features that exist in `src/features/`
+3. **Project Structure:** Show actual `src/` directory structure
+4. **Commands:** List all pnpm scripts from `package.json`
+5. **Path Aliases:** `@/*` → `src/*`, `@assets/*` → `assets/*`
+6. **Code Style:** TypeScript strict, NativeWind className, kebab-case files, PascalCase components, path aliases, named exports
+7. **Component Patterns:** `src/components/`, `src/components/ui/`, `_components/` subfolders
+8. **Routing:** expo-router conventions, route groups, `_layout.tsx`
+9. **Git Workflow:** `ft/`, `fix/`, `refactor/` branches, conventional commits
+10. **Feature Architecture:** Show the standard feature module pattern
+11. **Feature Guide:** For each feature directory in `src/features/`, add a section with:
+    - Key files (provider, hooks, service interface if it exists)
+    - The active provider (from config or by checking which provider files exist)
+    - Development patterns (how to extend, how to use hooks)
+
+## How to manage commands
+
+Check each command in `.claude/commands/`:
+- If `add-provider.md` exists but no feature has a `providers/` directory → delete it
+- If features with providers exist but `add-provider.md` is missing → create it with the standard template
+
+Do NOT add or remove other commands — they are user-selected.
+
+## After regenerating
+
+1. Show a summary of what changed
+2. Commit: `git add CLAUDE.md .claude/ && git commit -m "chore: update workflow files via /evaluate"`

--- a/setup/workflows/templates/commands/new-component.md
+++ b/setup/workflows/templates/commands/new-component.md
@@ -1,0 +1,14 @@
+Create a new reusable component.
+
+Ask the user for:
+1. Component name (PascalCase)
+2. Location: `src/components/ui/` (base component) or `src/components/` (shared component)
+
+Create the file at: `src/components/{ui/}{kebab-case-name}.tsx`
+
+Follow these patterns:
+- Use NativeWind className for all styling
+- Use `useThemeColors()` from `@/hooks/use-theme-colors` for dynamic theme values if needed
+- Export as a named export (not default)
+- Include a TypeScript props interface: `{Name}Props`
+- Use path aliases (`@/`) for imports

--- a/setup/workflows/templates/commands/new-screen.md
+++ b/setup/workflows/templates/commands/new-screen.md
@@ -1,0 +1,16 @@
+Create a new screen/route in the app.
+
+Ask the user for:
+1. Screen name (kebab-case)
+2. Route group: `(tabs)`, `(auth)`, or root level
+3. Does it need its own layout file? (Y/n)
+
+Create the screen file at: `src/app/{group}/{screen-name}.tsx`
+
+Use this pattern:
+- Import `ThemedView`, `ThemedText` from `@/components/`
+- Use NativeWind className for all styling
+- Use path aliases for imports
+- Export as default (required by expo-router)
+
+If layout needed, also create: `src/app/{group}/_layout.tsx`

--- a/setup/workflows/templates/commands/run-checks.md
+++ b/setup/workflows/templates/commands/run-checks.md
@@ -1,0 +1,8 @@
+Run the full check suite and report results.
+
+Execute in sequence:
+1. `pnpm lint`
+2. `pnpm typecheck`
+3. `pnpm test --no-coverage`
+
+Report pass/fail for each step. If any step fails, investigate the errors and suggest fixes before moving to the next step.


### PR DESCRIPTION
## Summary

Adds agentic workflow file generation to the setup wizard. When developers run `pnpm run setup`, they can now choose between:

- **Manual mode** — generates a minimal CLAUDE.md with tech stack, structure, and commands
- **Agentic mode** — generates full CLAUDE.md with coding conventions, feature-specific guidance, plus `.claude/settings.json` and selectable slash commands

### Setup Wizard Flow

```
◇ Development workflow: Agentic
◇ Select agents: Claude Code
◇ Select workflow commands: /add-feature, /new-screen, /run-checks, /evaluate, ...
```

### What Gets Generated

| File | Purpose |
|------|---------|
| `CLAUDE.md` | Full project context tailored to selected features |
| `.claude/settings.json` | Pre-configured permissions (pnpm, git, gh) |
| `.claude/commands/add-feature.md` | Scaffold a new feature module |
| `.claude/commands/new-screen.md` | Create a new route/screen |
| `.claude/commands/add-provider.md` | Add provider to existing feature |
| `.claude/commands/run-checks.md` | Lint + typecheck + test |
| `.claude/commands/new-component.md` | Scaffold a component |
| `.claude/commands/create-issue.md` | Create a GitHub issue |
| `.claude/commands/create-branch.md` | Create a feature branch |
| `.claude/commands/evaluate.md` | Self-updating codebase scanner |

### Key Design Decisions

- **Registry pattern** — command and feature section definitions live as structured data, making it easy to add new agents later
- **`/evaluate` is self-contained** — after setup deletes the `setup/` directory, the evaluate command carries all generation rules in its markdown prompt
- **Feature-aware** — CLAUDE.md only documents features that were selected; `/add-provider` is only available when provider-based features exist
- **Quick mode defaults to manual** — no workflow generation overhead

## Test plan

- [x] 126/126 tests pass
- [x] TypeScript strict check passes
- [x] Lint clean
- [x] Dry-run shows `Workflow: manual` for quick mode
- [ ] Fresh clone → agentic mode → verify CLAUDE.md contains feature guides for selected features only
- [ ] Fresh clone → agentic mode → verify `.claude/commands/` contains selected commands
- [ ] Fresh clone → manual mode → verify minimal CLAUDE.md, no `.claude/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)