### PR TITLE
fix: implement theme font loading and apply to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   },
   "dependencies": {
     "@aws-amplify/react-native": "^1.3.3",
+    "@expo-google-fonts/ibm-plex-sans": "^0.4.1",
+    "@expo-google-fonts/inter": "^0.4.2",
+    "@expo-google-fonts/jetbrains-mono": "^0.4.1",
+    "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
     "@expo/vector-icons": "^15.0.2",
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@aws-amplify/react-native':
         specifier: ^1.3.3
         version: 1.3.3(react-native-get-random-values@2.0.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      '@expo-google-fonts/ibm-plex-sans':
+        specifier: ^0.4.1
+        version: 0.4.1
+      '@expo-google-fonts/inter':
+        specifier: ^0.4.2
+        version: 0.4.2
+      '@expo-google-fonts/jetbrains-mono':
+        specifier: ^0.4.1
+        version: 0.4.1
+      '@expo-google-fonts/plus-jakarta-sans':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.0.2(expo-font@14.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1148,6 +1160,18 @@ packages:
   '@eslint/plugin-kit@0.4.0':
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@expo-google-fonts/ibm-plex-sans@0.4.1':
+    resolution: {integrity: sha512-allsuhZbvKoKDTB/U8creFVYYzhI97Nw9MgyyNjFzqISNc/sURpA7ZY37Rr+IRI567OV9BWQ/ioUCjAQrVGRbw==}
+
+  '@expo-google-fonts/inter@0.4.2':
+    resolution: {integrity: sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==}
+
+  '@expo-google-fonts/jetbrains-mono@0.4.1':
+    resolution: {integrity: sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==}
+
+  '@expo-google-fonts/plus-jakarta-sans@0.4.2':
+    resolution: {integrity: sha512-6LYVmVGwjQvH+uzzWlVc9+oMj4lkNQ41aymVDjO+x8aFk8kCye20wOyLomYMZaMezA++Uf1mZRCw3W3Fy/hxEA==}
 
   '@expo/cli@54.0.11':
     resolution: {integrity: sha512-ik9p8+JTOuVXS462+vFPV0qnWRBXIR1bPmoVKO8xQWw6Yk+K6UlU2GrM2ch7kA3JlSJE/MGsNyN8CB0zFZbVbQ==}
@@ -7707,6 +7731,14 @@ snapshots:
     dependencies:
       '@eslint/core': 0.16.0
       levn: 0.4.1
+
+  '@expo-google-fonts/ibm-plex-sans@0.4.1': {}
+
+  '@expo-google-fonts/inter@0.4.2': {}
+
+  '@expo-google-fonts/jetbrains-mono@0.4.1': {}
+
+  '@expo-google-fonts/plus-jakarta-sans@0.4.2': {}
 
   '@expo/cli@54.0.11(expo-router@6.0.11)(expo@54.0.13)(graphql@15.8.0)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))':
     dependencies:

--- a/src/components/themed-text.tsx
+++ b/src/components/themed-text.tsx
@@ -19,12 +19,18 @@ export function ThemedText({
   ...rest
 }: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
-  const { tint } = useThemeColors();
+  const { tint, fonts } = useThemeColors();
+
+  const fontFamily =
+    type === 'title' || type === 'subtitle' || type === 'defaultSemiBold'
+      ? (fonts.bold ?? fonts.semiBold)
+      : fonts.regular;
 
   return (
     <Text
       style={[
         { color },
+        fontFamily ? { fontFamily } : undefined,
         type === 'default' ? styles.default : undefined,
         type === 'title' ? styles.title : undefined,
         type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,

--- a/src/features/theme/font-assets.ts
+++ b/src/features/theme/font-assets.ts
@@ -1,0 +1,42 @@
+import {
+  Inter_400Regular,
+  Inter_600SemiBold,
+  Inter_700Bold,
+} from '@expo-google-fonts/inter';
+import {
+  PlusJakartaSans_400Regular,
+  PlusJakartaSans_600SemiBold,
+  PlusJakartaSans_700Bold,
+} from '@expo-google-fonts/plus-jakarta-sans';
+import {
+  IBMPlexSans_400Regular,
+  IBMPlexSans_600SemiBold,
+  IBMPlexSans_700Bold,
+} from '@expo-google-fonts/ibm-plex-sans';
+import { JetBrainsMono_400Regular } from '@expo-google-fonts/jetbrains-mono';
+
+/**
+ * Maps font family names (as defined in theme presets) to the font assets
+ * that need to be loaded via useFonts(). The keys in each inner record
+ * become the font names available to fontFamily in styles.
+ */
+export const FONT_MAP: Record<string, Record<string, number>> = {
+  Inter: {
+    Inter_400Regular,
+    Inter_600SemiBold,
+    Inter_700Bold,
+  },
+  'Plus Jakarta Sans': {
+    PlusJakartaSans_400Regular,
+    PlusJakartaSans_600SemiBold,
+    PlusJakartaSans_700Bold,
+  },
+  'IBM Plex Sans': {
+    IBMPlexSans_400Regular,
+    IBMPlexSans_600SemiBold,
+    IBMPlexSans_700Bold,
+  },
+  'JetBrains Mono': {
+    JetBrainsMono_400Regular,
+  },
+};

--- a/src/features/theme/font-map.ts
+++ b/src/features/theme/font-map.ts
@@ -1,0 +1,25 @@
+export const FONT_FAMILY_MAP: Record<
+  string,
+  { regular: string; semiBold: string; bold: string }
+> = {
+  Inter: {
+    regular: 'Inter_400Regular',
+    semiBold: 'Inter_600SemiBold',
+    bold: 'Inter_700Bold',
+  },
+  'Plus Jakarta Sans': {
+    regular: 'PlusJakartaSans_400Regular',
+    semiBold: 'PlusJakartaSans_600SemiBold',
+    bold: 'PlusJakartaSans_700Bold',
+  },
+  'IBM Plex Sans': {
+    regular: 'IBMPlexSans_400Regular',
+    semiBold: 'IBMPlexSans_600SemiBold',
+    bold: 'IBMPlexSans_700Bold',
+  },
+  'JetBrains Mono': {
+    regular: 'JetBrainsMono_400Regular',
+    semiBold: 'JetBrainsMono_400Regular',
+    bold: 'JetBrainsMono_400Regular',
+  },
+};

--- a/src/features/theme/hooks/use-theme.ts
+++ b/src/features/theme/hooks/use-theme.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext, useCallback } from 'react';
 import type { ThemeConfig } from '@/types';
+import { FONT_FAMILY_MAP } from '../font-map';
 
 interface ThemeContextValue {
   config: ThemeConfig;
@@ -35,6 +36,11 @@ export function useTheme() {
     spacing,
     borderRadius: config.borderRadius,
     shadows: config.shadows,
+    fonts: FONT_FAMILY_MAP[config.typography.fontFamily.sans] ?? {
+      regular: undefined,
+      semiBold: undefined,
+      bold: undefined,
+    },
     mode,
     setMode,
     isDark: mode === 'dark',

--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -1,3 +1,4 @@
 export { BasekitThemeProvider } from './theme-provider';
 export { useTheme, ThemeContext } from './hooks/use-theme';
 export { generateTailwindTheme } from './utils/generate-tailwind';
+export { FONT_FAMILY_MAP } from './font-map';

--- a/src/features/theme/theme-provider.tsx
+++ b/src/features/theme/theme-provider.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+import { useFonts } from 'expo-font';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { themeConfig } from '@/config/theme.config';
 import { ThemeContext } from './hooks/use-theme';
 import { basekitConfig } from '@/config/basekit.config';
+import { FONT_MAP } from './font-assets';
 
 export function BasekitThemeProvider({ children }: { children: React.ReactNode }) {
   if (!basekitConfig.features.theme?.enabled) {
@@ -16,12 +18,26 @@ function ThemeProviderInner({ children }: { children: React.ReactNode }) {
   const systemColorScheme = useColorScheme();
   const [modeOverride, setModeOverride] = useState<'light' | 'dark' | 'system'>('system');
 
+  // Load fonts for the active theme
+  const sansFamily = themeConfig.typography.fontFamily.sans;
+  const monoFamily = themeConfig.typography.fontFamily.mono;
+  const fontsToLoad: Record<string, number> = {
+    ...(FONT_MAP[sansFamily] ?? {}),
+    ...(FONT_MAP[monoFamily] ?? {}),
+  };
+
+  const [fontsLoaded] = useFonts(fontsToLoad);
+
   const resolvedMode: 'light' | 'dark' =
     modeOverride === 'system' ? (systemColorScheme ?? 'light') : modeOverride;
 
   const setMode = (mode: 'light' | 'dark' | 'system') => {
     setModeOverride(mode);
   };
+
+  if (!fontsLoaded) {
+    return null;
+  }
 
   return (
     <ThemeContext.Provider value={{ config: themeConfig, mode: resolvedMode, setMode }}>

--- a/src/hooks/use-theme-colors.ts
+++ b/src/hooks/use-theme-colors.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { ThemeContext } from '@/features/theme/hooks/use-theme';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { FONT_FAMILY_MAP } from '@/features/theme/font-map';
 
 /**
  * Returns theme-aware colors. Uses the theme system when available,
@@ -14,6 +15,13 @@ export function useThemeColors() {
   if (themeCtx) {
     const mode = themeCtx.mode;
     const c = themeCtx.config.colors;
+    const sansFamily = themeCtx.config.typography.fontFamily.sans;
+    const fonts = FONT_FAMILY_MAP[sansFamily] ?? {
+      regular: undefined,
+      semiBold: undefined,
+      bold: undefined,
+    };
+
     return {
       text: c.surface[mode].background === '#ffffff' ? '#11181C' : '#ECEDEE',
       background: c.surface[mode].background,
@@ -25,6 +33,7 @@ export function useThemeColors() {
       secondary: c.secondary,
       accent: c.accent,
       semantic: c.semantic,
+      fonts,
       mode,
       isDark: mode === 'dark',
     };
@@ -43,6 +52,7 @@ export function useThemeColors() {
     secondary: null,
     accent: null,
     semantic: null,
+    fonts: { regular: undefined, semiBold: undefined, bold: undefined },
     mode: colorScheme,
     isDark: colorScheme === 'dark',
   };


### PR DESCRIPTION
## Summary

Fixes the theme system's font pipeline — fonts defined in presets (Inter, Plus Jakarta Sans, IBM Plex Sans) were never loaded or applied to components.

### What was broken

1. No font files or font packages installed
2. No `useFonts()` call to load fonts at runtime
3. `ThemedText` used hardcoded system fonts, never read from theme config
4. `useThemeColors()` didn't expose font family info

### What this fixes

- **Installs `@expo-google-fonts/*`** packages for all 3 presets (Inter, Plus Jakarta Sans, IBM Plex Sans, JetBrains Mono)
- **Loads fonts in `BasekitThemeProvider`** via `useFonts()` — only loads fonts for the active preset
- **`ThemedText` now applies `fontFamily`** from the theme (bold/semiBold for titles, regular for body text)
- **`useThemeColors()` exposes `fonts`** — `{ regular, semiBold, bold }` font names
- **`useTheme()` exposes `fonts`** — same font names for direct access
- **Null-renders while fonts load** — prevents FOUT (flash of unstyled text)

### New files

- `src/features/theme/font-assets.ts` — maps theme family names to Google Font asset imports
- `src/features/theme/font-map.ts` — maps family names to loaded font name strings (separate file to avoid circular imports)

## Test plan

- [x] 126/126 tests pass
- [x] TypeScript strict check passes
- [x] Lint clean
- [ ] Fresh clone → select Bold preset → `pnpm start` → verify Plus Jakarta Sans font renders
- [ ] Fresh clone → select Corporate preset → verify IBM Plex Sans renders
- [ ] Fresh clone → No theme → verify system fonts still work (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)