### PR TITLE
fix: delete entire feature directories when stripping unselected features

### DIFF
--- a/setup/__tests__/generator.test.ts
+++ b/setup/__tests__/generator.test.ts
@@ -74,12 +74,13 @@ describe('resolveFeaturesToStrip', () => {
     expect(result.routesToRemove).toContain('src/app/(auth)/');
   });
 
-  it('should collect all files from removed features', () => {
+  it('should collect entire feature directory for removed features', () => {
     const selected = { auth: 'amplify' };
     const result = resolveFeaturesToStrip(testManifest, selected);
 
     expect(result.filesToRemove).toContain('src/features/analytics/');
-    expect(result.filesToRemove).toContain('src/features/analytics/providers/amplify.ts');
+    expect(result.filesToRemove).toContain('src/services/analytics.interface.ts');
+    expect(result.filesToRemove).toContain('src/types/analytics.types.ts');
   });
 });
 

--- a/setup/generator.ts
+++ b/setup/generator.ts
@@ -41,11 +41,12 @@ export function resolveFeaturesToStrip(
   for (const [featureName, feature] of Object.entries(manifest.features)) {
     if (!(featureName in selectedFeatures)) {
       featuresToRemove.push(featureName);
-      filesToRemove.push(...feature.sharedFiles);
+      // Delete the entire feature directory instead of individual files
+      filesToRemove.push(`src/features/${featureName}/`);
+      // Also remove related service interface and types files
+      filesToRemove.push(`src/services/${featureName}.interface.ts`);
+      filesToRemove.push(`src/types/${featureName}.types.ts`);
       routesToRemove.push(...feature.routes);
-      for (const provider of Object.values(feature.providers)) {
-        filesToRemove.push(...provider.files);
-      }
     } else {
       const selectedProvider = selectedFeatures[featureName];
       for (const [providerName, provider] of Object.entries(feature.providers)) {

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -181,6 +181,25 @@ async function main() {
   await removeFeatureFiles(PROJECT_ROOT, allFilesToRemove);
   s.stop(color.green(`Removed ${stripResult.featuresToRemove.length} features`));
 
+  // Step 2a: Rewrite types/index.ts to remove exports for deleted type files
+  s.start('Cleaning type exports');
+  const typesIndexPath = path.join(PROJECT_ROOT, 'src/types/index.ts');
+  if (await fs.pathExists(typesIndexPath)) {
+    const typesContent = await fs.readFile(typesIndexPath, 'utf-8');
+    const cleanedTypes = typesContent
+      .split('\n')
+      .filter((line) => {
+        // Remove lines that re-export from deleted type files
+        for (const removed of stripResult.featuresToRemove) {
+          if (line.includes(`./${removed}.types`)) return false;
+        }
+        return true;
+      })
+      .join('\n');
+    await fs.writeFile(typesIndexPath, cleanedTypes);
+  }
+  s.stop(color.green('Cleaned type exports'));
+
   // Step 2b: Rewrite service factory files to remove references to deleted providers
   s.start('Rewriting service factories');
   for (const [featureName, selectedProvider] of Object.entries(answers.features)) {


### PR DESCRIPTION
## Summary

Fixes a bug where unselected features left behind empty directories and unlisted files in `src/features/`.

**Root cause:** The setup wizard was deleting individual files from the manifest's `sharedFiles` list. But the manifest didn't list every file (e.g., context files, additional hooks), and `fs.remove` on files leaves empty parent directories.

**Fix:**
- Delete the entire `src/features/{name}/` directory when a feature is not selected (instead of individual files)
- Also remove `src/services/{name}.interface.ts` and `src/types/{name}.types.ts`
- Rewrite `src/types/index.ts` to remove re-exports for deleted type files (prevents import errors)

## Test plan

- [x] 126/126 tests pass
- [x] TypeScript strict check passes
- [ ] Fresh clone → don't select analytics/crash-reporting → verify `src/features/` only contains selected features

🤖 Generated with [Claude Code](https://claude.com/claude-code)