### PR TITLE
fix: strip feature docs for unselected features

### DIFF
--- a/setup/generator.ts
+++ b/setup/generator.ts
@@ -43,9 +43,10 @@ export function resolveFeaturesToStrip(
       featuresToRemove.push(featureName);
       // Delete the entire feature directory instead of individual files
       filesToRemove.push(`src/features/${featureName}/`);
-      // Also remove related service interface and types files
+      // Also remove related service interface, types, and docs files
       filesToRemove.push(`src/services/${featureName}.interface.ts`);
       filesToRemove.push(`src/types/${featureName}.types.ts`);
+      filesToRemove.push(`docs/features/${featureName}.md`);
       routesToRemove.push(...feature.routes);
     } else {
       const selectedProvider = selectedFeatures[featureName];


### PR DESCRIPTION
## Summary

One-line fix: adds `docs/features/{name}.md` to the strip list for unselected features.

The setup wizard was deleting `src/features/`, `src/services/`, and `src/types/` files for unselected features, but left behind the static documentation files in `docs/features/`.

## Test plan

- [x] 126/126 tests pass
- [ ] Fresh clone → don't select analytics → verify `docs/features/analytics.md` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)