### PR TITLE
fix: address critical bugs and design issues from code review

### DIFF
--- a/.claude/commands/ss-android.md
+++ b/.claude/commands/ss-android.md
@@ -1,0 +1,6 @@
+Take a screenshot from the connected Android device via ADB and display it.
+
+Steps:
+1. Run `adb exec-out screencap -p > /tmp/android-screenshot.png`
+2. Read and display the image at `/tmp/android-screenshot.png`
+3. Describe what you see on screen

--- a/.claude/commands/ss-android.md
+++ b/.claude/commands/ss-android.md
@@ -1,6 +1,8 @@
-Take a screenshot from the connected Android device via ADB and display it.
+Take a screenshot from the connected Android device via ADB and copy it to the macOS clipboard.
 
-Steps:
-1. Run `adb exec-out screencap -p > /tmp/android-screenshot.png`
-2. Read and display the image at `/tmp/android-screenshot.png`
-3. Describe what you see on screen
+Run this command:
+```
+adb exec-out screencap -p > /tmp/sc.png && osascript -e 'set the clipboard to (read (POSIX file "/tmp/sc.png") as TIFF picture)' && rm /tmp/sc.png
+```
+
+Tell the user the screenshot is copied to their clipboard and they can Cmd+V to paste it anywhere.

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,12 +1,19 @@
-import { Tabs } from 'expo-router';
+import { Redirect, Tabs } from 'expo-router';
 import React from 'react';
 
 import { HapticTab } from '@/components/haptic-tab';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useThemeColors } from '@/hooks/use-theme-colors';
+import { useAuth } from '@/features/auth';
+import { basekitConfig } from '@/config/basekit.config';
 
 export default function TabLayout() {
   const { tint } = useThemeColors();
+  const { user, isLoading } = useAuth();
+
+  if (basekitConfig.features.auth.enabled && !isLoading && !user) {
+    return <Redirect href="/(auth)/login" />;
+  }
 
   return (
     <Tabs

--- a/src/config/basekit.config.ts
+++ b/src/config/basekit.config.ts
@@ -5,10 +5,10 @@ export interface BasekitConfig {
     scheme: string;
   };
   features: {
-    auth: { enabled: boolean; provider: 'amplify' | 'firebase' | 'supabase' | 'clerk' };
-    analytics: { enabled: boolean; provider: 'amplify' | 'mixpanel' | 'segment' | 'posthog' };
-    crashReporting: { enabled: boolean; provider: 'sentry' | 'bugsnag' | 'datadog' };
-    notifications: { enabled: boolean; provider: 'amplify' | 'firebase' | 'onesignal' };
+    auth: { enabled: boolean; provider: 'amplify' };
+    analytics: { enabled: boolean; provider: 'amplify' };
+    crashReporting: { enabled: boolean; provider: 'sentry' };
+    notifications: { enabled: boolean; provider: 'amplify' };
     i18n: { enabled: boolean; defaultLocale: string };
     offlineStorage: { enabled: boolean; provider: 'mmkv' | 'async-storage' };
     onboarding: { enabled: boolean };

--- a/src/features/analytics/analytics-provider.tsx
+++ b/src/features/analytics/analytics-provider.tsx
@@ -12,8 +12,6 @@ function AnalyticsProviderInner({ children }: { children: React.ReactNode }) {
     createAnalyticsService().then(setService);
   }, []);
 
-  if (!service) return null;
-
   return (
     <AnalyticsContext.Provider value={service}>
       {children}

--- a/src/features/crash-reporting/crash-reporting-provider.tsx
+++ b/src/features/crash-reporting/crash-reporting-provider.tsx
@@ -12,8 +12,6 @@ function CrashReportingProviderInner({ children }: { children: React.ReactNode }
     createCrashReportingService().then(setService);
   }, []);
 
-  if (!service) return null;
-
   return (
     <CrashReportingContext.Provider value={service}>
       {children}

--- a/src/features/notifications/notification-provider.tsx
+++ b/src/features/notifications/notification-provider.tsx
@@ -12,8 +12,6 @@ function NotificationProviderInner({ children }: { children: React.ReactNode }) 
     createNotificationService().then(setService);
   }, []);
 
-  if (!service) return null;
-
   return (
     <NotificationContext.Provider value={service}>
       {children}

--- a/src/features/offline-storage/create-storage-service.ts
+++ b/src/features/offline-storage/create-storage-service.ts
@@ -4,8 +4,10 @@ import { noOpStorage } from './no-op-storage';
 
 const providers: Record<string, () => Promise<StorageService>> = {
   mmkv: () => import('./providers/mmkv').then((m) => m.mmkvStorageService),
-  'async-storage': () =>
-    import('./providers/async-storage').then((m) => m.asyncStorageService),
+  'async-storage': async () => {
+    const m = await import('./providers/async-storage');
+    return m.createAsyncStorageService();
+  },
 };
 
 export async function createStorageService(): Promise<StorageService> {

--- a/src/features/offline-storage/providers/async-storage.ts
+++ b/src/features/offline-storage/providers/async-storage.ts
@@ -3,19 +3,26 @@ import type { StorageService } from '@/services/storage.interface';
 import type { StorageValue } from '@/types';
 
 const cache = new Map<string, string>();
-let initialized = false;
+let hydratePromise: Promise<void> | null = null;
 
-async function hydrate() {
-  if (initialized) return;
-  const keys = await AsyncStorage.getAllKeys();
-  const entries = await AsyncStorage.getMany(keys);
-  Object.entries(entries).forEach(([key, value]) => {
-    if (value !== null) cache.set(key, value);
-  });
-  initialized = true;
+function hydrate(): Promise<void> {
+  if (hydratePromise) return hydratePromise;
+  hydratePromise = (async () => {
+    const keys = await AsyncStorage.getAllKeys();
+    const entries = await AsyncStorage.getMany(keys);
+    for (const [key, value] of Object.entries(entries)) {
+      if (value !== null) cache.set(key, value);
+    }
+  })();
+  return hydratePromise;
 }
 
-export const asyncStorageService: StorageService = {
+export async function createAsyncStorageService(): Promise<StorageService> {
+  await hydrate();
+  return asyncStorageService;
+}
+
+const asyncStorageService: StorageService = {
   get<T extends StorageValue>(key: string): T | null {
     const value = cache.get(key);
     if (value === undefined) return null;
@@ -51,4 +58,4 @@ export const asyncStorageService: StorageService = {
   },
 };
 
-export { hydrate as hydrateAsyncStorage };
+export { asyncStorageService };

--- a/src/features/offline-storage/storage-provider.tsx
+++ b/src/features/offline-storage/storage-provider.tsx
@@ -12,8 +12,6 @@ function StorageProviderInner({ children }: { children: React.ReactNode }) {
     createStorageService().then(setStorage);
   }, []);
 
-  if (!storage) return null;
-
   return (
     <StorageContext.Provider value={storage}>
       {children}

--- a/src/features/theme/theme-provider.tsx
+++ b/src/features/theme/theme-provider.tsx
@@ -35,13 +35,9 @@ function ThemeProviderInner({ children }: { children: React.ReactNode }) {
     setModeOverride(mode);
   };
 
-  if (!fontsLoaded) {
-    return null;
-  }
-
   return (
     <ThemeContext.Provider value={{ config: themeConfig, mode: resolvedMode, setMode }}>
-      {children}
+      {fontsLoaded ? children : null}
     </ThemeContext.Provider>
   );
 }

--- a/src/lib/amplify/configure.ts
+++ b/src/lib/amplify/configure.ts
@@ -1,9 +1,14 @@
 import { basekitConfig } from '@/config/basekit.config';
 
-let configured = false;
+let configurePromise: Promise<void> | null = null;
 
-export async function configureAmplify(): Promise<void> {
-  if (configured) return;
+export function configureAmplify(): Promise<void> {
+  if (configurePromise) return configurePromise;
+  configurePromise = doConfigureAmplify();
+  return configurePromise;
+}
+
+async function doConfigureAmplify(): Promise<void> {
 
   const { features } = basekitConfig;
 
@@ -44,7 +49,6 @@ export async function configureAmplify(): Promise<void> {
       },
     });
 
-    configured = true;
   } catch (error) {
     console.warn(
       '[amplify] Failed to configure Amplify:',

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -25,9 +25,3 @@ apiClient.interceptors.request.use(async (config) => {
   return config;
 });
 
-apiClient.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    return Promise.reject(error);
-  },
-);

--- a/src/store/storage-middleware.ts
+++ b/src/store/storage-middleware.ts
@@ -48,19 +48,29 @@ function createAsyncStorageAdapter(): StateStorage {
   }
 }
 
+let cachedStorage: StateStorage | null = null;
+
 export function createZustandStorage(): StateStorage {
+  if (cachedStorage) return cachedStorage;
+
   if (!basekitConfig.features.offlineStorage?.enabled) {
-    return memoryStorage();
+    cachedStorage = memoryStorage();
+    return cachedStorage;
   }
 
   const provider = basekitConfig.features.offlineStorage?.provider;
 
   switch (provider) {
     case 'mmkv':
-      return createMMKVStorage();
+      cachedStorage = createMMKVStorage();
+      break;
     case 'async-storage':
-      return createAsyncStorageAdapter();
+      cachedStorage = createAsyncStorageAdapter();
+      break;
     default:
-      return createMMKVStorage();
+      cachedStorage = createMMKVStorage();
+      break;
   }
+
+  return cachedStorage;
 }


### PR DESCRIPTION
## Summary

- **Fix AsyncStorage hydration bug**: `getMany()` was never called (dead code), and the original used `multiGet` which doesn't exist on the v3 API. Now uses correct `getMany` API, deduplicates with a promise, and hydration completes before the service is returned.
- **Stop providers from blocking app render**: Removed `return null` during async service initialization in StorageProvider, AnalyticsProvider, CrashReportingProvider, NotificationProvider, and ThemeProvider. Children now render immediately; services arrive asynchronously via context updates.
- **Add auth navigation guard**: Tabs layout now redirects unauthenticated users to `/(auth)/login` when auth is enabled, preventing unauthorized access via deep links or direct navigation.
- **Restrict provider types to implemented providers**: Config types now only allow `amplify` (auth/analytics/notifications), `sentry` (crash), `mmkv`/`async-storage` (storage) — no more phantom `firebase`, `supabase`, `clerk`, etc. that silently fall back to no-ops.
- **Hoist Zustand storage creation**: Cache the `StateStorage` instance so it isn't recreated on every persist middleware access (was creating new MMKV instances repeatedly).
- **Deduplicate `configureAmplify`**: Uses promise-based singleton pattern to prevent race conditions under React StrictMode double-effect invocation.
- **Remove no-op response interceptor**: Removed the placeholder response error interceptor that just re-rejected.
- **Add `/ss-android` slash command**: Captures a screenshot from a connected Android device via ADB and copies it to the macOS clipboard.
- **Add Claude Code slash commands**: Ported `/main`, `/pull`, `/pr`, `/update-pr`, `/check-worktree` from the platform repo.
- **Change Metro port to 8090**: Avoids conflict with port 8081.

## Test plan

- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm test` passes (126 tests, 24 suites)
- [ ] Manual: verify app boots without blank screen flash
- [ ] Manual: verify unauthenticated users are redirected to login
- [ ] Manual: verify AsyncStorage provider correctly persists/retrieves data
- [x] Manual: verify `/ss-android` captures screenshot to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)