### PR TITLE
feat: add Claude Code slash commands

### DIFF
--- a/.claude/commands/check-worktree.md
+++ b/.claude/commands/check-worktree.md
@@ -1,0 +1,25 @@
+Check if the current worktree has any work that needs to be saved before deletion.
+
+**Instructions:**
+
+Run ALL of these checks in parallel, then present a summary.
+
+**Check 1: Uncommitted changes**
+- Run `git status --porcelain` to detect staged, unstaged, and untracked files.
+
+**Check 2: Unpushed commits**
+- Run `git log @{upstream}..HEAD --oneline 2>/dev/null` to find commits not yet pushed.
+- If upstream is not set, run `git log origin/main..HEAD --oneline` instead (branch may never have been pushed).
+
+**Check 3: Existing PR**
+- Run `gh pr view --json url,title,state 2>/dev/null` to check if a PR exists for this branch.
+
+**Check 4: Stashed changes**
+- Run `git stash list` to check for any stashed work.
+
+**Check 5: Branch info**
+- Run `git branch --show-current` to get the branch name.
+- Run `git log --oneline -5` to show recent commits for context.
+
+**Present Summary:**
+Display a clear status report with a table showing status of each check, using "None" for clean checks. If everything is clean and a PR exists (or there are no branch-specific commits), say "Safe to delete." Otherwise, say "Action needed before deleting." and list what to do.

--- a/.claude/commands/main.md
+++ b/.claude/commands/main.md
@@ -1,0 +1,1 @@
+Switch to the main branch. Run `git checkout main && git pull origin main` to ensure the branch is up to date.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,35 @@
+Create a new PR from the current branch against main.
+
+**Instructions:**
+
+**Step 1: Branch check**
+- Run `git branch --show-current` to get the current branch name.
+- If the branch is `main` or `master`:
+  - Run `git status` to check for uncommitted changes. If there are no changes, STOP and tell the user: "No changes to create a PR from."
+  - Generate a short, descriptive branch name based on the staged/unstaged changes (e.g., `fix/login-validation`, `feat/add-user-search`).
+  - Run `git checkout -b <branch-name>` to create and switch to the new branch.
+
+**Step 2: Stage and commit ALL changes**
+- Run `git add -A` to stage all changed, added, and deleted files.
+- Run `git status` to check if there is anything staged.
+- If there are staged changes, create a single commit with a descriptive message using a HEREDOC.
+- If there is nothing to commit, skip this step.
+
+**Step 3: Push the branch to remote**
+- Run `git push -u origin $(git branch --show-current)` to push the branch and set upstream tracking.
+
+**Step 4: Gather all changes in the branch**
+Run these commands in parallel:
+- `git log main..HEAD --oneline` to see all commits on this branch.
+- `git diff main...HEAD --stat` to see a summary of all files changed.
+- `git diff main...HEAD` to see the full diff of all changes.
+
+**Step 5: Analyze changes and draft the PR**
+- Analyze ALL commits and the full diff to understand the complete set of changes.
+- Draft a concise PR title (under 70 characters) that captures the overall purpose.
+- Draft a PR description using the format: Summary (1-3 bullet points), Changes (bulleted list), Test plan (bulleted checklist), and "Generated with Claude Code".
+
+**Step 6: Create the PR**
+- Use `gh pr create --base main --title "..." --body "$(cat <<'EOF' ... EOF)"` to create the PR.
+- Use a HEREDOC for the body to ensure correct formatting.
+- After creating, show the PR URL to the user.

--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -1,0 +1,1 @@
+Pull the latest changes from the remote for the current branch. Run `git pull origin $(git branch --show-current)` to update the current branch.

--- a/.claude/commands/update-pr.md
+++ b/.claude/commands/update-pr.md
@@ -1,0 +1,36 @@
+Update the PR for the current branch by committing all changes, force-pushing, and updating the PR description.
+
+**Instructions:**
+
+**Step 1: Safety check**
+- Run `git branch --show-current` to get the current branch name.
+- If the branch is `main` or `master`, STOP immediately and tell the user: "Cannot update PR from the main/master branch. Switch to a feature branch first."
+
+**Step 2: Stage and commit everything**
+- Run `git add -A` to stage all files (tracked, untracked, deleted — everything).
+- Run `git status` to confirm what's being committed.
+- Create a single commit with a descriptive message based on the changes. Use a HEREDOC for the commit message.
+- If there are no changes to commit, skip this step and proceed.
+
+**Step 3: Force-push to remote**
+- Run `git push --force-with-lease origin $(git branch --show-current)` to push all changes to the remote branch, overwriting whatever was there.
+
+**Step 4: Gather all changes in the branch**
+Run these commands in parallel:
+- `git log main..HEAD --oneline` to see all commits on this branch since it diverged from main.
+- `git diff main...HEAD --stat` to see a summary of all files changed.
+- `git diff main...HEAD` to see the full diff of all changes.
+
+**Step 5: Find the existing PR**
+- Run `gh pr list --head $(git branch --show-current) --json number,title,body,url --limit 1` to find the PR for this branch.
+- If no PR exists, tell the user "No PR found for this branch. Use /pr to create one." and STOP.
+
+**Step 6: Analyze changes and draft updates**
+- Analyze ALL commits and the full diff to understand the complete set of changes.
+- Draft a concise PR title (under 70 characters) that captures the overall purpose.
+- Draft a PR description using the format: Summary (1-3 bullet points), Changes (bulleted list), Test plan (bulleted checklist), and "Generated with Claude Code".
+
+**Step 7: Update the PR**
+- Use `gh pr edit <number> --title "..." --body "$(cat <<'EOF' ... EOF)"` to update the PR title and body.
+- Use a HEREDOC for the body to ensure correct formatting.
+- After updating, show the PR URL to the user.


### PR DESCRIPTION
## Summary
- Ported 5 slash commands from the platform repo: `/main`, `/pull`, `/pr`, `/update-pr`, `/check-worktree`

## Changes
- `.claude/commands/main.md` — switch to main and pull
- `.claude/commands/pull.md` — pull latest for current branch
- `.claude/commands/pr.md` — create a PR from current branch
- `.claude/commands/update-pr.md` — commit, force-push, update PR description
- `.claude/commands/check-worktree.md` — safety check before deleting a worktree

## Test plan
- [x] Commands are valid markdown with correct instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)