### PR TITLE
fix: fix Supabase Docker Compose startup issues

### DIFF
--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -1,15 +1,14 @@
-version: "3.8"
-
 services:
   supabase-db:
     image: supabase/postgres:15.8.1.060
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: supabase
     volumes:
       - supabase-db-data:/var/lib/postgresql/data
+      - ./init/99-custom-roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-custom-roles.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U supabase_admin"]
       interval: 5s
@@ -56,7 +55,7 @@ services:
         condition: service_healthy
 
   supabase-studio:
-    image: supabase/studio:20250113-83c4c07
+    image: supabase/studio:latest
     ports:
       - "3100:3000"
     environment:

--- a/supabase/init/99-custom-roles.sql
+++ b/supabase/init/99-custom-roles.sql
@@ -1,0 +1,3 @@
+-- Set passwords for Supabase internal roles
+ALTER ROLE supabase_auth_admin WITH PASSWORD 'postgres' LOGIN;
+ALTER ROLE authenticator WITH PASSWORD 'postgres' LOGIN;


### PR DESCRIPTION
## Summary
- Fix Docker Compose so `pnpm supabase:up` works out of the box

## Changes
- Remove obsolete `version` field (Docker Compose warning)
- Fix `supabase/studio` image tag — old tag didn't exist in registry
- Map DB port to `5433:5432` to avoid conflicts with existing Postgres instances
- Add `supabase/init/99-custom-roles.sql` — sets passwords for `supabase_auth_admin` and `authenticator` roles after Supabase migrations run

## Test plan
- [x] `pnpm supabase:up` starts all 6 services successfully
- [x] Auth health check returns 200: `curl http://localhost:8000/auth/v1/health`
- [x] Playwright: register new user → auto-login → home screen
- [x] Playwright: clear session → login with same credentials → home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)