### PR TITLE
feat: add comprehensive E2E tests (Playwright + Maestro)

### DIFF
--- a/e2e/.maestro/auth-forgot-password.yaml
+++ b/e2e/.maestro/auth-forgot-password.yaml
@@ -1,0 +1,15 @@
+appId: com.mycompany.myapp
+---
+- launchApp:
+    clearState: true
+
+# Should land on login screen
+- assertVisible: "Welcome Back"
+
+# Navigate to forgot password
+- tapOn: "Forgot password?"
+- assertVisible: "Reset Password"
+
+# Go back to login
+- tapOn: "Back"
+- assertVisible: "Welcome Back"

--- a/e2e/.maestro/auth-login.yaml
+++ b/e2e/.maestro/auth-login.yaml
@@ -1,0 +1,22 @@
+appId: com.mycompany.myapp
+---
+- launchApp:
+    clearState: true
+
+# Should land on login screen
+- assertVisible: "Welcome Back"
+- assertVisible: "Sign in to your account"
+
+# Fill in credentials
+- tapOn: "you@example.com"
+- inputText: "test@example.com"
+- tapOn: "Enter your password"
+- inputText: "Test1234!"
+
+# Submit
+- tapOn: "Sign In"
+
+# Should navigate to home
+- assertVisible:
+    text: "Home"
+    timeout: 10000

--- a/e2e/.maestro/auth-register.yaml
+++ b/e2e/.maestro/auth-register.yaml
@@ -1,0 +1,29 @@
+appId: com.mycompany.myapp
+---
+- launchApp:
+    clearState: true
+
+# Should land on login screen
+- assertVisible: "Welcome Back"
+
+# Navigate to register
+- tapOn: "Sign Up"
+- assertVisible: "Create Account"
+
+# Fill in registration form
+- tapOn: "you@example.com"
+- inputText: "maestro-test@example.com"
+- tapOn: "At least 8 characters"
+- inputText: "Test1234!"
+- tapOn: "Re-enter your password"
+- inputText: "Test1234!"
+
+# Submit
+- tapOn:
+    text: "Create Account"
+    index: 1
+
+# Should auto-login and go to home
+- assertVisible:
+    text: "Home"
+    timeout: 15000

--- a/e2e/.maestro/explore-features.yaml
+++ b/e2e/.maestro/explore-features.yaml
@@ -1,0 +1,14 @@
+appId: com.mycompany.myapp
+---
+- launchApp
+
+# Navigate to Explore tab (user must be logged in)
+- tapOn: "Explore"
+- assertVisible: "Explore"
+
+# Verify feature sections are visible
+- assertVisible: "Features"
+- scrollDown
+
+# Verify core infrastructure section
+- assertVisible: "Core Infrastructure"

--- a/e2e/.maestro/full-flow.yaml
+++ b/e2e/.maestro/full-flow.yaml
@@ -1,0 +1,45 @@
+appId: com.mycompany.myapp
+name: Full User Journey
+---
+- launchApp:
+    clearState: true
+
+# 1. Login screen should be visible
+- assertVisible: "Welcome Back"
+
+# 2. Navigate to register
+- tapOn: "Sign Up"
+- assertVisible: "Create Account"
+
+# 3. Go back to login
+- tapOn: "Back"
+- assertVisible: "Welcome Back"
+
+# 4. Navigate to forgot password
+- tapOn: "Forgot password?"
+- assertVisible: "Reset Password"
+
+# 5. Go back to login
+- tapOn: "Back"
+- assertVisible: "Welcome Back"
+
+# 6. Login with test credentials
+- tapOn: "you@example.com"
+- inputText: "test@example.com"
+- tapOn: "Enter your password"
+- inputText: "Test1234!"
+- tapOn: "Sign In"
+
+# 7. Home screen should load
+- assertVisible:
+    text: "Home"
+    timeout: 10000
+- assertVisible: "Starter Kit"
+
+# 8. Switch to Explore tab
+- tapOn: "Explore"
+- assertVisible: "Explore"
+
+# 9. Switch back to Home
+- tapOn: "Home"
+- assertVisible: "Starter Kit"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,47 +1,78 @@
-# E2E Testing with Maestro
+# E2E Testing
 
-This directory contains end-to-end test flows using [Maestro](https://maestro.mobile.dev/).
+Two testing strategies: **Maestro** for native device testing and **Playwright** for web browser testing.
 
-## Prerequisites
+## Maestro (Native)
 
-Install the Maestro CLI:
+Tests run on iOS Simulator or Android Emulator.
+
+### Prerequisites
 
 ```bash
-# macOS / Linux
 curl -Ls "https://get.maestro.mobile.dev" | bash
 ```
 
-For Windows, see the [Maestro installation docs](https://maestro.mobile.dev/getting-started/installing-maestro).
+### Running
 
-## Running Tests
+```bash
+# Start app on simulator/emulator
+pnpm start
 
-1. Start the dev server and run the app on a simulator/emulator:
+# Run all Maestro tests
+pnpm test:e2e
 
-   ```bash
-   pnpm start
-   ```
+# Run a specific flow
+maestro test e2e/.maestro/auth-login.yaml
+```
 
-2. Run all E2E tests:
-
-   ```bash
-   pnpm test:e2e
-   ```
-
-   Or run a specific flow:
-
-   ```bash
-   maestro test e2e/.maestro/app-launch.yaml
-   ```
-
-## Test Flows
+### Flows
 
 | Flow | Description |
 | --- | --- |
-| `app-launch.yaml` | Verifies the app launches and the Home screen is visible |
-| `tab-navigation.yaml` | Verifies switching between Home and Explore tabs |
+| `app-launch.yaml` | App launches and Home screen is visible |
+| `tab-navigation.yaml` | Switch between Home and Explore tabs |
+| `auth-login.yaml` | Login with email/password |
+| `auth-register.yaml` | Register and auto-login |
+| `auth-forgot-password.yaml` | Navigate to forgot password and back |
+| `explore-features.yaml` | Browse the Explore tab features |
+| `full-flow.yaml` | Complete user journey: auth screens → login → navigation |
+
+## Playwright (Web)
+
+Tests run in a headless Chromium browser — no simulator required. Great for CI.
+
+### Prerequisites
+
+```bash
+pnpm add -D @playwright/test
+npx playwright install chromium
+```
+
+### Running
+
+```bash
+# Start Supabase (if auth tests need it)
+pnpm supabase:up
+
+# Run all Playwright tests (auto-starts web server)
+pnpm test:e2e:web
+
+# Run with UI mode
+npx playwright test --config=e2e/playwright/playwright.config.ts --ui
+
+# Run a specific test file
+npx playwright test --config=e2e/playwright/playwright.config.ts e2e/playwright/auth.spec.ts
+```
+
+### Test Files
+
+| File | Description |
+| --- | --- |
+| `auth.spec.ts` | Login, register, forgot password, invalid credentials |
+| `navigation.spec.ts` | Tab navigation, home screen content |
+| `error-boundary.spec.ts` | App recovery from errors |
 
 ## Writing New Tests
 
-Add new `.yaml` flow files to `e2e/.maestro/`. They will be picked up automatically when running `pnpm test:e2e`.
-
-See the [Maestro docs](https://maestro.mobile.dev/) for the full flow file reference.
+- **Maestro**: Add `.yaml` files to `e2e/.maestro/` — auto-discovered by `pnpm test:e2e`
+- **Playwright**: Add `.spec.ts` files to `e2e/playwright/` — auto-discovered by `pnpm test:e2e:web`

--- a/e2e/playwright/auth.spec.ts
+++ b/e2e/playwright/auth.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_EMAIL = `e2e-${Date.now()}@test.com`;
+const TEST_PASSWORD = 'Test1234!';
+
+test.describe('Authentication', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForURL('**/login');
+    await expect(page.getByText('Welcome Back')).toBeVisible();
+    await expect(page.getByText('Sign in to your account')).toBeVisible();
+  });
+
+  test('login page has required fields', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByPlaceholder('you@example.com')).toBeVisible();
+    await expect(page.getByPlaceholder('Enter your password')).toBeVisible();
+    await expect(page.getByText('Sign In', { exact: true })).toBeVisible();
+    await expect(page.getByText('Forgot password?')).toBeVisible();
+  });
+
+  test('login with invalid credentials shows error', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByPlaceholder('you@example.com').fill('invalid@test.com');
+    await page.getByPlaceholder('Enter your password').fill('wrongpass');
+    await page.getByText('Sign In', { exact: true }).click();
+
+    await expect(page.getByText(/Invalid login credentials|Sign-in failed/)).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('navigate to register page', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('link', { name: 'Sign Up' }).click();
+    await page.waitForURL('**/register');
+    await expect(page.getByRole('heading', { name: 'Create Account' })).toBeVisible();
+  });
+
+  test('register page has required fields', async ({ page }) => {
+    await page.goto('/register');
+    await expect(page.getByPlaceholder('you@example.com')).toBeVisible();
+    await expect(page.getByPlaceholder('At least 8 characters')).toBeVisible();
+    await expect(page.getByPlaceholder('Re-enter your password')).toBeVisible();
+  });
+
+  test('register and auto-login', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByPlaceholder('you@example.com').fill(TEST_EMAIL);
+    await page.getByPlaceholder('At least 8 characters').fill(TEST_PASSWORD);
+    await page.getByPlaceholder('Re-enter your password').fill(TEST_PASSWORD);
+
+    await page.locator('[class*="bg-blue-600"]').click();
+
+    // Should auto-login and navigate away from auth screens
+    await page.waitForURL('/', { timeout: 15000 });
+    // Verify tab bar is visible (home screen loaded)
+    await expect(page.getByRole('tab', { name: /Home/ })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('login with registered credentials', async ({ page }) => {
+    // First register a user for this test
+    const loginEmail = `login-${Date.now()}@test.com`;
+    await page.goto('/register');
+    await page.getByPlaceholder('you@example.com').fill(loginEmail);
+    await page.getByPlaceholder('At least 8 characters').fill(TEST_PASSWORD);
+    await page.getByPlaceholder('Re-enter your password').fill(TEST_PASSWORD);
+    await page.locator('[class*="bg-blue-600"]').click();
+    await page.waitForURL('/', { timeout: 15000 });
+
+    // Now clear session and login
+    await page.evaluate(() => { localStorage.clear(); sessionStorage.clear(); });
+    await page.goto('/login');
+    await page.getByPlaceholder('you@example.com').fill(loginEmail);
+    await page.getByPlaceholder('Enter your password').fill(TEST_PASSWORD);
+    await page.getByText('Sign In', { exact: true }).click();
+
+    await page.waitForURL('/', { timeout: 10000 });
+    await expect(page.getByRole('tab', { name: /Home/ })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('navigate to forgot password', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('link', { name: 'Forgot password?' }).click();
+    await page.waitForURL('**/forgot-password');
+    await expect(page.getByRole('heading', { name: 'Reset Password' })).toBeVisible();
+  });
+});

--- a/e2e/playwright/error-boundary.spec.ts
+++ b/e2e/playwright/error-boundary.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Error Boundary', () => {
+  test('app recovers from navigation to invalid route', async ({ page }) => {
+    // Navigate to a route that doesn't exist
+    await page.goto('/some-nonexistent-route');
+
+    // App should not crash — either shows 404 or redirects
+    // The error boundary should catch any render errors
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+});

--- a/e2e/playwright/navigation.spec.ts
+++ b/e2e/playwright/navigation.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    const url = page.url();
+    if (url.includes('login')) {
+      // Register a new user to ensure we can log in
+      const email = `nav-${Date.now()}@test.com`;
+      await page.goto('/register');
+      await page.getByPlaceholder('you@example.com').fill(email);
+      await page.getByPlaceholder('At least 8 characters').fill('Test1234!');
+      await page.getByPlaceholder('Re-enter your password').fill('Test1234!');
+      await page.locator('[class*="bg-blue-600"]').click();
+      await page.waitForURL('/', { timeout: 15000 });
+    }
+  });
+
+  test('home screen shows app info', async ({ page }) => {
+    await expect(page.getByText('Starter Kit').first()).toBeVisible();
+    await expect(page.getByText('Tech Stack')).toBeVisible();
+    await expect(page.getByText('Quick Start')).toBeVisible();
+  });
+
+  test('tab navigation between Home and Explore', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: /Home/ })).toBeVisible();
+
+    // Navigate to Explore via URL (more reliable than tab clicks on web — expo-router rebuilds DOM)
+    await page.goto('/explore');
+    await expect(page.getByText('Features', { exact: true })).toBeVisible({ timeout: 5000 });
+
+    // Navigate back to Home
+    await page.goto('/');
+    await expect(page.getByText('Quick Start')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('home screen shows tech badges', async ({ page }) => {
+    await expect(page.getByText('Expo SDK 54', { exact: true })).toBeVisible();
+    await expect(page.getByText('React Native 0.81', { exact: true })).toBeVisible();
+    await expect(page.getByText('TypeScript', { exact: true })).toBeVisible();
+    await expect(page.getByText('NativeWind v4', { exact: true })).toBeVisible();
+    await expect(page.getByText('Zustand', { exact: true })).toBeVisible();
+  });
+});

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  timeout: 30000,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:8090',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: 'pnpm start --web --port 8090',
+    url: 'http://localhost:8090',
+    reuseExistingServer: true,
+    timeout: 60000,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "setup": "tsx setup/index.ts",
     "typecheck": "tsc --noEmit",
     "test:e2e": "maestro test e2e/.maestro/",
+    "test:e2e:web": "npx playwright test --config=e2e/playwright/playwright.config.ts",
     "supabase:up": "docker compose -f supabase/docker-compose.yml up -d",
     "supabase:down": "docker compose -f supabase/docker-compose.yml down",
     "supabase:reset": "docker compose -f supabase/docker-compose.yml down -v && docker compose -f supabase/docker-compose.yml up -d"
@@ -75,6 +76,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "^1.1.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/fs-extra": "^11.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.1.0
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/jest-native':
         specifier: ^5.4.3
         version: 5.4.3(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1565,6 +1568,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -3740,6 +3748,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5191,6 +5204,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -8558,6 +8581,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-collection@1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -11195,6 +11222,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13108,6 +13138,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add 12 Playwright web E2E tests covering auth, navigation, and error handling
- Add 5 new Maestro native E2E flows covering auth and navigation
- All 12 Playwright tests pass in 11.5s against local Supabase

## Playwright Tests (Web) — `pnpm test:e2e:web`

| Suite | Tests | Coverage |
|-------|-------|----------|
| **Auth** | 8 | Login redirect, form validation, invalid credentials, register + auto-login, login flow, forgot password |
| **Navigation** | 3 | Home content, tab switching (Home ↔ Explore), tech badges |
| **Error Boundary** | 1 | Recovery from invalid routes |

## Maestro Flows (Native) — `pnpm test:e2e`

| Flow | Description |
|------|-------------|
| `auth-login.yaml` | Email/password sign-in |
| `auth-register.yaml` | Registration with auto-login |
| `auth-forgot-password.yaml` | Forgot password navigation |
| `explore-features.yaml` | Browse feature list |
| `full-flow.yaml` | Complete user journey |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (126/126 unit tests)
- [x] `pnpm test:e2e:web` passes (12/12 Playwright tests)
- [ ] `pnpm test:e2e` — requires simulator with running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)