### PR TITLE
feat: email verification flow with Inbucket dev mail server

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  inbucket:
+    image: inbucket/inbucket:latest
+    ports:
+      - "9000:9000"   # Web UI
+      - "2500:2500"   # SMTP
+    environment:
+      INBUCKET_SMTP_DEFAULTACCEPT: "true"
+      INBUCKET_STORAGE_TYPE: memory
+
+networks:
+  default:
+    name: infra

--- a/package.json
+++ b/package.json
@@ -16,9 +16,13 @@
     "typecheck": "tsc --noEmit",
     "test:e2e": "maestro test e2e/.maestro/",
     "test:e2e:web": "npx playwright test --config=e2e/playwright/playwright.config.ts",
-    "supabase:up": "docker compose -f supabase/docker-compose.yml up -d",
+    "infra:up": "docker compose -f infra/docker-compose.yml up -d",
+    "infra:down": "docker compose -f infra/docker-compose.yml down",
+    "supabase:up": "pnpm infra:up && docker compose -f supabase/docker-compose.yml up -d",
     "supabase:down": "docker compose -f supabase/docker-compose.yml down",
-    "supabase:reset": "docker compose -f supabase/docker-compose.yml down -v && docker compose -f supabase/docker-compose.yml up -d"
+    "supabase:reset": "docker compose -f supabase/docker-compose.yml down -v && pnpm supabase:up",
+    "dev:up": "pnpm infra:up && pnpm supabase:up",
+    "dev:down": "pnpm supabase:down && pnpm infra:down"
   },
   "dependencies": {
     "@aws-amplify/react-native": "^1.3.3",

--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -15,6 +15,7 @@ export default function AuthLayout() {
     >
       <Stack.Screen name="login" options={{ title: 'Sign In', headerShown: false }} />
       <Stack.Screen name="register" options={{ title: 'Create Account' }} />
+      <Stack.Screen name="confirm-email" options={{ title: 'Verify Email' }} />
       <Stack.Screen name="forgot-password" options={{ title: 'Reset Password' }} />
       <Stack.Screen name="verify-code" options={{ title: 'Verify Code' }} />
     </Stack>

--- a/src/app/(auth)/confirm-email.tsx
+++ b/src/app/(auth)/confirm-email.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { FormProvider } from 'react-hook-form';
+import { z } from 'zod';
+import { useAppForm, FormInput, requiredString } from '@/features/forms';
+import { useAuth } from '@/features/auth';
+
+const confirmEmailSchema = z.object({
+  token: requiredString,
+});
+
+type ConfirmEmailFormData = z.infer<typeof confirmEmailSchema>;
+
+export default function ConfirmEmailScreen() {
+  const { verifyEmail, resendVerificationEmail } = useAuth();
+  const router = useRouter();
+  const { email } = useLocalSearchParams<{ email: string }>();
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [resendSuccess, setResendSuccess] = useState(false);
+
+  const form = useAppForm<ConfirmEmailFormData>(confirmEmailSchema, {
+    defaultValues: { token: '' },
+  });
+
+  const onSubmit = async (data: ConfirmEmailFormData) => {
+    if (!email) {
+      setError('Email is required. Please go back and register again.');
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await verifyEmail(email, data.token);
+
+      if (result.success) {
+        router.replace('/(tabs)');
+      } else {
+        setError(result.error ?? 'Verification failed. Please try again.');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'An unexpected error occurred.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!email) return;
+
+    setIsResending(true);
+    setResendSuccess(false);
+    setError(null);
+
+    try {
+      await resendVerificationEmail(email);
+      setResendSuccess(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to resend email.');
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1 bg-white dark:bg-gray-900"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <View className="flex-1 justify-center px-6">
+        <Text className="text-5xl text-center mb-4">📧</Text>
+        <Text className="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">
+          Check Your Email
+        </Text>
+        <Text className="text-base text-center text-gray-500 dark:text-gray-400 mb-2">
+          {"We've sent a verification code to"}
+        </Text>
+        <Text className="text-base font-semibold text-center text-gray-900 dark:text-gray-100 mb-6">
+          {email}
+        </Text>
+
+        <View className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 mb-4">
+          <Text className="text-sm text-blue-700 dark:text-blue-400 text-center">
+            View emails at{' '}
+            <Text className="font-semibold">http://localhost:9000</Text>
+            {' '}(Inbucket)
+          </Text>
+        </View>
+
+        {error && (
+          <View className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 mb-4">
+            <Text className="text-sm text-red-700 dark:text-red-400">{error}</Text>
+          </View>
+        )}
+
+        {resendSuccess && (
+          <View className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3 mb-4">
+            <Text className="text-sm text-green-700 dark:text-green-400">
+              Verification email sent! Check your inbox.
+            </Text>
+          </View>
+        )}
+
+        <FormProvider {...form}>
+          <FormInput
+            name="token"
+            label="Verification Code"
+            placeholder="Enter the 6-digit code"
+            keyboardType="number-pad"
+            autoComplete="one-time-code"
+          />
+
+          <Pressable
+            className="bg-blue-600 rounded-lg py-3.5 mt-2 items-center active:bg-blue-700"
+            onPress={form.handleSubmit(onSubmit)}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text className="text-white font-semibold text-base">Verify Email</Text>
+            )}
+          </Pressable>
+        </FormProvider>
+
+        <Pressable
+          className="mt-4 items-center"
+          onPress={handleResend}
+          disabled={isResending}
+        >
+          {isResending ? (
+            <ActivityIndicator size="small" />
+          ) : (
+            <Text className="text-blue-600 dark:text-blue-400 text-sm">
+              {"Didn't receive the code? Resend"}
+            </Text>
+          )}
+        </Pressable>
+
+        <Pressable
+          className="mt-3 items-center"
+          onPress={() => router.back()}
+        >
+          <Text className="text-gray-500 dark:text-gray-400 text-sm">Back to Register</Text>
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/app/(auth)/register.tsx
+++ b/src/app/(auth)/register.tsx
@@ -20,7 +20,7 @@ const registerSchema = z
 type RegisterFormData = z.infer<typeof registerSchema>;
 
 export default function RegisterScreen() {
-  const { signUp, signIn } = useAuth();
+  const { signUp } = useAuth();
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -37,13 +37,11 @@ export default function RegisterScreen() {
       const result = await signUp(data.email, data.password);
 
       if (result.success) {
-        // Auto-login after registration (email verification is disabled)
-        const loginResult = await signIn(data.email, data.password);
-        if (loginResult.success) {
-          router.replace('/(tabs)');
-        } else {
-          router.replace('/(auth)/login');
-        }
+        // Registration successful — navigate to email verification
+        router.push({
+          pathname: '/(auth)/confirm-email',
+          params: { email: data.email },
+        });
       } else {
         setError(result.error ?? 'Sign-up failed. Please try again.');
       }

--- a/src/features/auth/auth-context.ts
+++ b/src/features/auth/auth-context.ts
@@ -9,6 +9,8 @@ export interface AuthContextValue {
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
   confirmResetPassword: (email: string, code: string, newPassword: string) => Promise<void>;
+  verifyEmail: (email: string, token: string) => Promise<AuthResult>;
+  resendVerificationEmail: (email: string) => Promise<void>;
   getSession: () => Promise<Session | null>;
 }
 

--- a/src/features/auth/auth-provider.tsx
+++ b/src/features/auth/auth-provider.tsx
@@ -97,6 +97,24 @@ function AuthProviderInner({ children }: { children: React.ReactNode }) {
     [],
   );
 
+  const verifyEmail = useCallback(async (email: string, token: string): Promise<AuthResult> => {
+    const service = serviceRef.current;
+    if (!service) return { success: false, error: 'Auth service not initialized' };
+
+    const result = await service.verifyEmail(email, token);
+    if (result.success && result.user) {
+      setUser(result.user);
+    }
+    return result;
+  }, []);
+
+  const resendVerificationEmail = useCallback(async (email: string): Promise<void> => {
+    const service = serviceRef.current;
+    if (!service) return;
+
+    await service.resendVerificationEmail(email);
+  }, []);
+
   const getSession = useCallback(async (): Promise<Session | null> => {
     const service = serviceRef.current;
     if (!service) return null;
@@ -113,9 +131,11 @@ function AuthProviderInner({ children }: { children: React.ReactNode }) {
       signOut,
       resetPassword,
       confirmResetPassword,
+      verifyEmail,
+      resendVerificationEmail,
       getSession,
     }),
-    [user, isLoading, signIn, signUp, signOut, resetPassword, confirmResetPassword, getSession],
+    [user, isLoading, signIn, signUp, signOut, resetPassword, confirmResetPassword, verifyEmail, resendVerificationEmail, getSession],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -10,6 +10,8 @@ const noOpAuthContext: AuthContextValue = {
   signOut: async () => {},
   resetPassword: async () => {},
   confirmResetPassword: async () => {},
+  verifyEmail: async () => ({ success: false }),
+  resendVerificationEmail: async () => {},
   getSession: async () => null,
 };
 

--- a/src/features/auth/no-op-auth.ts
+++ b/src/features/auth/no-op-auth.ts
@@ -6,6 +6,8 @@ export const noOpAuth: AuthService = {
   signOut: async () => {},
   resetPassword: async () => {},
   confirmResetPassword: async () => {},
+  verifyEmail: async () => ({ success: false }),
+  resendVerificationEmail: async () => {},
   getCurrentUser: async () => null,
   getSession: async () => null,
   onAuthStateChange: () => () => {},

--- a/src/features/auth/providers/amplify.ts
+++ b/src/features/auth/providers/amplify.ts
@@ -143,6 +143,14 @@ export const amplifyAuthService: AuthService = {
     }
   },
 
+  async verifyEmail() {
+    return { success: false, error: 'Email verification not supported with Amplify provider' };
+  },
+
+  async resendVerificationEmail() {
+    console.warn('[auth:amplify] resendVerificationEmail not implemented');
+  },
+
   getCurrentUser: mapCurrentUser,
   getSession: mapSession,
 

--- a/src/features/auth/providers/supabase.ts
+++ b/src/features/auth/providers/supabase.ts
@@ -86,6 +86,41 @@ export const supabaseAuthService: AuthService = {
     }
   },
 
+  async verifyEmail(email: string, token: string) {
+    try {
+      const { data, error } = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: 'email',
+      });
+
+      if (error) {
+        return { success: false, error: error.message };
+      }
+
+      if (data.user) {
+        return { success: true, user: mapUser(data.user) };
+      }
+
+      return { success: false, error: 'Verification failed' };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Verification failed',
+      };
+    }
+  },
+
+  async resendVerificationEmail(email: string) {
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email,
+    });
+    if (error) {
+      throw new Error(error.message);
+    }
+  },
+
   async getCurrentUser() {
     const { data: { user } } = await supabase.auth.getUser();
     return user ? mapUser(user) : null;

--- a/src/services/auth.interface.ts
+++ b/src/services/auth.interface.ts
@@ -6,6 +6,8 @@ export interface AuthService {
   signOut(): Promise<void>;
   resetPassword(email: string): Promise<void>;
   confirmResetPassword(email: string, code: string, newPassword: string): Promise<void>;
+  verifyEmail(email: string, token: string): Promise<AuthResult>;
+  resendVerificationEmail(email: string): Promise<void>;
   getCurrentUser(): Promise<User | null>;
   getSession(): Promise<Session | null>;
   onAuthStateChange(callback: (user: User | null) => void): () => void;

--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -33,30 +33,17 @@ services:
       GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
       GOTRUE_MAILER_AUTOCONFIRM: "false"
       GOTRUE_SMS_AUTOCONFIRM: "true"
-      # Inbucket SMTP configuration
+      # Inbucket SMTP (runs in infra/docker-compose.yml)
       GOTRUE_SMTP_HOST: inbucket
       GOTRUE_SMTP_PORT: 2500
       GOTRUE_SMTP_ADMIN_EMAIL: admin@localhost
       GOTRUE_MAILER_URLPATHS_CONFIRMATION: "/verify"
       GOTRUE_MAILER_URLPATHS_RECOVERY: "/recover"
       GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "/email-change"
-      # Use OTP type for mobile-friendly verification
       GOTRUE_MAILER_OTP_EXP: 3600
     depends_on:
       supabase-db:
         condition: service_healthy
-      inbucket:
-        condition: service_started
-
-  inbucket:
-    image: inbucket/inbucket:latest
-    ports:
-      - "9000:9000"   # Web UI
-      - "2500:2500"   # SMTP
-      - "1100:1100"   # REST API
-    environment:
-      INBUCKET_SMTP_DEFAULTACCEPT: "true"
-      INBUCKET_STORAGE_TYPE: memory
 
   supabase-rest:
     image: postgrest/postgrest:v12.2.3
@@ -124,6 +111,11 @@ services:
         condition: service_started
       supabase-rest:
         condition: service_started
+
+networks:
+  default:
+    name: infra
+    external: true
 
 volumes:
   supabase-db-data:

--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
       API_EXTERNAL_URL: http://localhost:9999
-      GOTRUE_SITE_URL: http://localhost:3000
+      GOTRUE_SITE_URL: http://localhost:8090
       GOTRUE_URI_ALLOW_LIST: ""
       GOTRUE_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
       GOTRUE_JWT_EXP: 3600
@@ -31,14 +31,32 @@ services:
       GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:postgres@supabase-db:5432/supabase
       GOTRUE_DISABLE_SIGNUP: "false"
       GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
-      GOTRUE_MAILER_AUTOCONFIRM: "true"
+      GOTRUE_MAILER_AUTOCONFIRM: "false"
       GOTRUE_SMS_AUTOCONFIRM: "true"
+      # Inbucket SMTP configuration
+      GOTRUE_SMTP_HOST: inbucket
+      GOTRUE_SMTP_PORT: 2500
+      GOTRUE_SMTP_ADMIN_EMAIL: admin@localhost
       GOTRUE_MAILER_URLPATHS_CONFIRMATION: "/verify"
       GOTRUE_MAILER_URLPATHS_RECOVERY: "/recover"
       GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "/email-change"
+      # Use OTP type for mobile-friendly verification
+      GOTRUE_MAILER_OTP_EXP: 3600
     depends_on:
       supabase-db:
         condition: service_healthy
+      inbucket:
+        condition: service_started
+
+  inbucket:
+    image: inbucket/inbucket:latest
+    ports:
+      - "9000:9000"   # Web UI
+      - "2500:2500"   # SMTP
+      - "1100:1100"   # REST API
+    environment:
+      INBUCKET_SMTP_DEFAULTACCEPT: "true"
+      INBUCKET_STORAGE_TYPE: memory
 
   supabase-rest:
     image: postgrest/postgrest:v12.2.3


### PR DESCRIPTION
## Summary
- Full email verification flow using Inbucket as a local dev mail server — zero external dependencies
- Separated infra and Supabase Docker Compose files for reusability
- Register → Check Email → Enter OTP → Verified + Auto-login

## Changes

### Infrastructure Split
- `infra/docker-compose.yml` — shared services (Inbucket) on `infra` network
- `supabase/docker-compose.yml` — joins external `infra` network, removed Inbucket
- New scripts: `infra:up/down`, `dev:up/down`, `supabase:up` chains `infra:up`

### Docker (Inbucket)
- Inbucket container (SMTP :2500, Web UI :9000) in `infra/`
- GoTrue configured with SMTP to Inbucket
- `GOTRUE_MAILER_AUTOCONFIRM` disabled — emails required

### Auth Service Interface
- Add `verifyEmail(email, token)` → `AuthResult`
- Add `resendVerificationEmail(email)` → `void`
- Implemented in Supabase provider via `verifyOtp` + `resend`
- Stub implementations in Amplify provider and no-op auth

### Screens
- **Register** — navigates to `confirm-email` after signup
- **confirm-email.tsx** (new) — OTP input, resend button, Inbucket link
- **Auth layout** — added `confirm-email` route

## Usage
```bash
pnpm dev:up        # Start infra + Supabase
pnpm start         # Start app
# Register → check http://localhost:9000 → enter OTP
pnpm dev:down      # Stop everything
```

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (126/126)
- [x] `pnpm dev:up` starts infra + Supabase on shared network
- [x] Playwright: register → email in Inbucket → enter OTP → home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)