### PR TITLE
chore: disable Claude Code background-job worktree isolation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,5 +47,8 @@
       "Bash(git reset --hard*)",
       "Bash(git clean -f*)"
     ]
+  },
+  "worktree": {
+    "bgIsolation": "none"
   }
 }


### PR DESCRIPTION
## Description

Sets `worktree.bgIsolation: none` in `.claude/settings.json` so Claude Code background jobs edit the shared checkout directly instead of being forced into a git worktree.

Applied across the team's Claude Code repos for consistent agent behavior (companion to the platform/hrm changes, where worktrees additionally break the Maven `git-commit-id-plugin` and yarn workspace `node_modules` hoisting).

Claude Code config only — no application/content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
